### PR TITLE
feat: Support for Python projects

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -151,6 +151,12 @@
                 templateUrl: 'static/components-<%= VERSION %>/scratch/scratch.html',
                 controllerAs: 'vm'
             })
+            .state('mlproject_python', {
+                url: '/mlproject/:userId/:projectId/python',
+                controller: 'PythonController',
+                templateUrl: 'static/components-<%= VERSION %>/python/python.html',
+                controllerAs: 'vm'
+            })
             .state('siteadmin', {
                 url: '/siteadmin',
                 controller: 'AdminController',

--- a/public/components/mlproject/mlproject.html
+++ b/public/components/mlproject/mlproject.html
@@ -37,6 +37,15 @@
             </div>
         </div>
     </div>
+    <div class="menucontainer" ng-if="project.type === 'text' || project.type === 'images'">
+        <div class="mlprojectmenu" style="max-width: 300px; font-size: 0.8em;">
+            <div class="mlprojectmenutitle">Python</div>
+            <div class="mlprojectmenudescription"><span class="badge">Beta</span> Try using the machine learning model you've trained from a Python program</div>
+            <div class="mlprojectmenubutton">
+                <button type="button" class="btn btn-primary" ui-sref="mlproject_python({ projectId : projectId, userId : userId })">Python</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div ng-if="isAuthenticated && !projectId" class="alert alert-danger pageheadermsg">

--- a/public/components/python/python.controller.js
+++ b/public/components/python/python.controller.js
@@ -1,0 +1,55 @@
+    (function () {
+
+        angular
+            .module('app')
+            .controller('PythonController', PythonController);
+
+        PythonController.$inject = [
+            'authService', 'projectsService', 'scratchkeysService',
+            '$stateParams', '$scope'
+        ];
+
+        function PythonController(authService, projectsService, scratchkeysService, $stateParams, $scope) {
+
+            var vm = this;
+            vm.authService = authService;
+
+            var alertId = 1;
+            vm.errors = [];
+            vm.warnings = [];
+            vm.dismissAlert = function (type, errIdx) {
+                vm[type].splice(errIdx, 1);
+            };
+            function displayAlert(type, errObj) {
+                if (!errObj) {
+                    errObj = {};
+                }
+                vm[type].push({ alertid : alertId++, message : errObj.message || errObj.error || 'Unknown error', status : errObj.status });
+            }
+
+            $scope.projectId = $stateParams.projectId;
+            $scope.userId = $stateParams.userId;
+
+            authService.getProfileDeferred()
+                .then(function (profile) {
+                    vm.profile = profile;
+
+                    return projectsService.getProject($scope.projectId, $scope.userId, profile.tenant);
+                })
+                .then(function (project) {
+                    $scope.project = project;
+
+                    if (project.type === 'text') {
+                        return scratchkeysService.getScratchKeys(project.id, $scope.userId, vm.profile.tenant);
+                    }
+                })
+                .then(function (resp) {
+                    if (resp) {
+                        $scope.scratchkey = resp[0];
+                    }
+                })
+                .catch(function (err) {
+                    displayAlert('errors', err.data);
+                });
+        }
+    }());

--- a/public/components/python/python.controller.js
+++ b/public/components/python/python.controller.js
@@ -30,6 +30,17 @@
             $scope.projectId = $stateParams.projectId;
             $scope.userId = $stateParams.userId;
 
+            $scope.testsource = 'local';
+            $scope.testdata = {
+                text      : 'The text that you want to test',
+                imagefile : 'my-test-image.jpg',
+                imageurl  : 'https://www.site-on-the-internet.com/image.jpg'
+            };
+
+            $scope.setSource = function (source) {
+                $scope.testsource = source;
+            };
+
             authService.getProfileDeferred()
                 .then(function (profile) {
                     vm.profile = profile;
@@ -39,7 +50,7 @@
                 .then(function (project) {
                     $scope.project = project;
 
-                    if (project.type === 'text') {
+                    if (project.type !== 'numbers') {
                         return scratchkeysService.getScratchKeys(project.id, $scope.userId, vm.profile.tenant);
                     }
                 })

--- a/public/components/python/python.css
+++ b/public/components/python/python.css
@@ -1,0 +1,32 @@
+.pythoncodebox {
+    font-size: 0.7em;
+    background: #ffffff;
+    overflow:auto;
+    width:auto;
+    border:solid gray;
+    border-width:.1em .1em .1em .8em;
+    padding:.2em .6em;
+}
+
+.pythoncodebox .pythoncode {
+    margin: 0;
+    line-height: 125%;
+}
+
+.pythoncodebox .pythoncode .pythoncomments {
+    color: #888888;
+}
+
+.pythoncodebox .pythoncode .pythonfunc {
+    color: #008800;
+    font-weight: bold;
+}
+
+.pythoncodebox .pythoncode .pythonfuncname {
+    color: #0066BB;
+    font-weight: bold;
+}
+
+.pythoncodebox .pythoncode .pythonop {
+    color: #333333;
+}

--- a/public/components/python/python.css
+++ b/public/components/python/python.css
@@ -30,3 +30,13 @@
 .pythoncodebox .pythoncode .pythonop {
     color: #333333;
 }
+
+.pythoncodebox .pythoncode .pythonimport {
+    color: #0e84b5;
+    font-weight: bold;
+}
+
+.pythoncodebox .pythoncode .pythonint {
+    color: #0000DD;
+    font-weight: bold;
+}

--- a/public/components/python/python.html
+++ b/public/components/python/python.html
@@ -99,7 +99,7 @@ result: '{{ project.labels[0] }}' with 81% confidence</pre></div>
             </div>
         </div>
         <div class="modelguidance" ng-if="project.type === 'text'">
-<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span>
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span class="pythonimport">requests</span>
 
 <span class="pythoncomments"># This function will pass your text to the machine learning model</span>
 <span class="pythoncomments"># and return the top result with the highest confidence</span>
@@ -111,7 +111,7 @@ result: '{{ project.labels[0] }}' with 81% confidence</pre></div>
 
     <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
         responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
-        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        topMatch <span class="pythonop">=</span> responseData[<span class="pythonint">0</span>]
         <span class="pythonfunc">return</span> topMatch
     <span class="pythonfunc">else</span>:
         response<span class="pythonop">.</span>raise_for_status()
@@ -129,7 +129,7 @@ confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
 </pre></div>
         </div>
         <div class="modelguidance" ng-if="project.type === 'images' && testsource === 'local'">
-<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span>
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span class="pythonimport">requests</span>
 
 <span class="pythoncomments"># Gets the contents of an image file to be sent to the</span>
 <span class="pythoncomments"># machine learning model for classifying</span>
@@ -149,7 +149,7 @@ confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
 
     <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
         responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
-        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        topMatch <span class="pythonop">=</span> responseData[<span class="pythonint">0</span>]
         <span class="pythonfunc">return</span> topMatch
     <span class="pythonfunc">else</span>:
         response<span class="pythonop">.</span>raise_for_status()
@@ -167,7 +167,7 @@ confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
 </pre></div>
         </div>
         <div class="modelguidance" ng-if="project.type === 'images' && testsource === 'web'">
-<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span><span class="pythonop">,</span> <span style="pythonimport">base64</span>
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span class="pythonimport">requests</span><span class="pythonop">,</span> <span class="pythonimport">base64</span>
 
 <span class="pythoncomments"># Gets the contents of an image on the Internet to be</span>
 <span class="pythoncomments"># sent to the machine learning model for classifying</span>
@@ -185,7 +185,7 @@ confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
 
     <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
         responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
-        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        topMatch <span class="pythonop">=</span> responseData[<span class="pythonint">0</span>]
         <span class="pythonfunc">return</span> topMatch
     <span class="pythonfunc">else</span>:
         response<span class="pythonop">.</span>raise_for_status()

--- a/public/components/python/python.html
+++ b/public/components/python/python.html
@@ -32,7 +32,7 @@
     <div ng-if="projectId && !project" class="loading"> </div>
 
     <div ng-if="project" class="alert alert-warning pageheadermsg" role="alert" style="margin-top: 1em">
-        <strong>Warning:</strong> This is a beta feature. Please report issues at https://github.com/IBM/taxinomitis/issues/11
+        <strong>Warning:</strong> This is a beta feature. Please <a href="mailto:dale.lane@uk.ibm.com">let me know</a> if you find any problems with it.
     </div>
 
     <div ng-if="project && project.labels.length <= 1" class="modelguidancecontainer">

--- a/public/components/python/python.html
+++ b/public/components/python/python.html
@@ -1,0 +1,122 @@
+<div ng-if="!isAuthenticated">
+    <div class="alert alert-warning pageheadermsg">
+        <strong>Not logged in</strong>
+    </div>
+    <div class="text-center">
+        <button class="btn btn-primary" ng-click="vm.authService.login()">Log In</button>
+    </div>
+</div>
+
+<div ng-if="isAuthenticated && !projectId" class="alert alert-danger pageheadermsg">
+    <strong>Error:</strong> Missing project id. Go back to <a ui-sref="projects">your projects</a>
+</div>
+
+<div ng-if="isAuthenticated && projectId">
+    <div class="jumbotron">
+        <h2 class="text-center">Using machine learning in Python</h2>
+    </div>
+    <div class="backbutton">
+        <a ui-sref="mlproject({ projectId : projectId, userId : userId  })">&lt; Back to project</a>
+    </div>
+
+    <div ng-repeat="error in vm.errors" class="alert alert-danger alert-dismissible pageheadermsg" role="alert" ng-click="vm.dismissAlert('errors', $index)">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Error:</strong> {{ error.message }}<br/>
+        <em ng-if="error.status >= 500">If this keeps happening, please <a ui-sref="help">let me know</a>.</em>
+    </div>
+    <div ng-repeat="warning in vm.warnings" class="alert alert-warning alert-dismissible pageheadermsg" role="alert" ng-click="vm.dismissAlert('warnings', $index)">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Warning:</strong> {{ warning.message }}
+    </div>
+
+    <div ng-if="projectId && !project" class="loading"> </div>
+
+    <div ng-if="project" class="alert alert-warning pageheadermsg" role="alert" style="margin-top: 1em">
+        <strong>Warning:</strong> This is a beta feature. Please report issues at https://github.com/IBM/taxinomitis/issues/11
+    </div>
+
+    <div ng-if="project && project.labels.length <= 1" class="modelguidancecontainer">
+        <div class="modelguidance">
+            <div class="modelstatusdetail">
+                Your project isn't ready to be used in Python yet.
+            </div>
+            <div class="modelstatusdetail">
+                Or go to the <a ui-sref="mlproject_models({ projectId : projectId, userId : userId })">Learn &amp; Test</a>
+                page for some tips on what to do next.
+            </div>
+        </div>
+    </div>
+
+    <div ng-if="project && project.labels.length > 1" style="margin: 2em;">
+        <div ng-if="scratchkey">
+            <div ng-if="!scratchkey.model">
+                <div class="alert alert-info" role="alert">
+                    You haven't trained a machine learning model yet.
+                </div>
+                <div>
+                    You can <strong><a href="" ui-sref="mlproject_models({ projectId : projectId, userId : userId })">train one now</a></strong> and then come back to start your Python project.
+                </div>
+            </div>
+        </div>
+        <div ng-hide="project.type === 'text'">
+            Python projects are only for text projects at the moment.
+        </div>
+    </div>
+
+    <div ng-if="scratchkey && scratchkey.model" class="modelguidancecontainer">
+        <div class="modelguidance">
+            <div class="modelstatusdetail">
+                If you know how to use Python, you can use the machine learning model
+                that you've trained from a Python program.
+            </div>
+            <div class="modelstatusdetail">
+                This page gives a simple example of how to do it.
+            </div>
+            <div class="modelstatusdetail">
+                Change <code><span style="background-color: #fff0f0">&quot;The text that you want to test&quot;</span></code>
+                to something different.
+            </div>
+            <div class="modelstatusdetail">
+                Running it will print something like:
+            </div>
+            <div class="modelstatusdetail"><pre>$ python yourscript.py
+result: '{{ project.labels[0] }}' with 81% confidence</pre></div>
+            <div class="modelstatusdetail">
+                If you've never used the <a href="http://docs.python-requests.org"><code>requests</code></a>
+                library before, you might need to <a href="http://docs.python-requests.org/en/master/user/install/#install">install it first</a>.
+                Ask your teacher for help if you're not sure how to do that.
+            </div>
+        </div>
+        <div class="modelguidance">
+<div style="font-size: 0.7em; background: #ffffff; overflow:auto;width:auto;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre style="margin: 0; line-height: 125%"><span style="color: #008800; font-weight: bold">import</span> <span style="color: #0e84b5; font-weight: bold">requests</span>
+
+<span style="color: #888888"># This function will pass your text to the machine learning model</span>
+<span style="color: #888888"># and return the top result with the highest confidence</span>
+<span style="color: #008800; font-weight: bold">def</span> <span style="color: #0066BB; font-weight: bold">classify</span>(text):
+    key <span style="color: #333333">=</span> &quot;{{ scratchkey.id }}&quot;
+    url <span style="color: #333333">=</span> &quot;https://machinelearningforkids.co.uk/api/scratch/&quot;+ key + &quot;/classify&quot;
+
+    response <span style="color: #333333">=</span> requests<span style="color: #333333">.</span>get(url, params<span style="color: #333333">=</span>{ &quot;data&quot; : text })
+
+    <span style="color: #008800; font-weight: bold">if</span> response<span style="color: #333333">.</span>ok:
+        responseData <span style="color: #333333">=</span> response<span style="color: #333333">.</span>json()
+        topMatch <span style="color: #333333">=</span> responseData[<span style="color: #0000DD; font-weight: bold">0</span>]
+        <span style="color: #008800; font-weight: bold">return</span> topMatch
+    <span style="color: #008800; font-weight: bold">else</span>:
+        response<span style="color: #333333">.</span>raise_for_status()
+
+
+<span style="color: #888888"># CHANGE THIS to something you want your machine learning model to classify</span>
+demo <span style="color: #333333">=</span> classify(<span style="background-color: #fff0f0">&quot;The text that you want to test&quot;</span>)
+
+label <span style="color: #333333">=</span> demo[&quot;class_name&quot;]
+confidence <span style="color: #333333">=</span> demo[&quot;confidence&quot;]
+
+
+<span style="color: #888888"># CHANGE THIS to do something different with the result</span>
+<span style="color: #008800; font-weight: bold">print</span> (&quot;result: &#39;%s&#39; with %d%% confidence&quot; <span style="color: #333333">%</span> (label, confidence))
+</pre></div>
+        </div>
+    </div>
+</div>
+

--- a/public/components/python/python.html
+++ b/public/components/python/python.html
@@ -58,63 +58,148 @@
                 </div>
             </div>
         </div>
-        <div ng-hide="project.type === 'text'">
-            Python projects are only for text projects at the moment.
+        <div ng-if="project.type === 'numbers'">
+            Python projects are not available for numbers models at the moment.
         </div>
     </div>
 
-    <div ng-if="scratchkey && scratchkey.model" class="modelguidancecontainer">
+    <div ng-if="scratchkey && scratchkey.model" class="modelguidancecontainer" ng-hide="project.type === 'numbers'">
         <div class="modelguidance">
             <div class="modelstatusdetail">
-                If you know how to use Python, you can use the machine learning model
-                that you've trained from a Python program.
+                If you know how to use Python, you can use this code to
+                <span ng-if="project.type === 'text'">submit text</span>
+                <span ng-if="project.type === 'images' && testsource === 'local'">submit an image file that you have on your computer</span>
+                <span ng-if="project.type === 'images' && testsource === 'web'">submit an image file from the Internet</span>
+                to the machine learning model that you've trained.
+            </div>
+            <div class="modelstatusdetail" ng-if="project.type==='text'">
+                Enter the text: <input style="padding-left: 1em; padding-right: 1em; width: 80%;" ng-model="testdata.text"></input>
+            </div>
+            <div class="modelstatusdetail" ng-if="project.type==='images' && testsource === 'local'">
+                Enter the name of your image file: <input style="padding-left: 1em; padding-right: 1em; width: 80%;" ng-model="testdata.imagefile"></input>
+            </div>
+            <div class="modelstatusdetail" ng-if="project.type==='images' && testsource === 'web'">
+                Enter the web address for the image: <input style="padding-left: 1em; padding-right: 1em; width: 90%;" ng-model="testdata.imageurl"></input>
             </div>
             <div class="modelstatusdetail">
-                This page gives a simple example of how to do it.
-            </div>
-            <div class="modelstatusdetail">
-                Change <code><span style="background-color: #fff0f0">&quot;The text that you want to test&quot;</span></code>
-                to something different.
-            </div>
-            <div class="modelstatusdetail">
-                Running it will print something like:
+                Running this code will print something like:
             </div>
             <div class="modelstatusdetail"><pre>$ python yourscript.py
 result: '{{ project.labels[0] }}' with 81% confidence</pre></div>
+            <div class="modelstatusdetail" ng-if="project.type==='images' && testsource === 'local'">
+                <a href="" ng-click="setSource('web')">Click here if you would prefer Python for submitting an image from the Internet</a>
+            </div>
+            <div class="modelstatusdetail" ng-if="project.type==='images' && testsource === 'web'">
+                <a href="" ng-click="setSource('local')">Click here if you would prefer Python for submitting an image file</a>
+            </div>
             <div class="modelstatusdetail">
                 If you've never used the <a href="http://docs.python-requests.org"><code>requests</code></a>
                 library before, you might need to <a href="http://docs.python-requests.org/en/master/user/install/#install">install it first</a>.
                 Ask your teacher for help if you're not sure how to do that.
             </div>
         </div>
-        <div class="modelguidance">
-<div style="font-size: 0.7em; background: #ffffff; overflow:auto;width:auto;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre style="margin: 0; line-height: 125%"><span style="color: #008800; font-weight: bold">import</span> <span style="color: #0e84b5; font-weight: bold">requests</span>
+        <div class="modelguidance" ng-if="project.type === 'text'">
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span>
 
-<span style="color: #888888"># This function will pass your text to the machine learning model</span>
-<span style="color: #888888"># and return the top result with the highest confidence</span>
-<span style="color: #008800; font-weight: bold">def</span> <span style="color: #0066BB; font-weight: bold">classify</span>(text):
-    key <span style="color: #333333">=</span> &quot;{{ scratchkey.id }}&quot;
-    url <span style="color: #333333">=</span> &quot;https://machinelearningforkids.co.uk/api/scratch/&quot;+ key + &quot;/classify&quot;
+<span class="pythoncomments"># This function will pass your text to the machine learning model</span>
+<span class="pythoncomments"># and return the top result with the highest confidence</span>
+<span class="pythonfunc">def</span> <span class="pythonfuncname">classify</span>(text):
+    key <span class="pythonop">=</span> &quot;{{ scratchkey.id }}&quot;
+    url <span class="pythonop">=</span> &quot;https://machinelearningforkids.co.uk/api/scratch/&quot;+ key + &quot;/classify&quot;
 
-    response <span style="color: #333333">=</span> requests<span style="color: #333333">.</span>get(url, params<span style="color: #333333">=</span>{ &quot;data&quot; : text })
+    response <span class="pythonop">=</span> requests<span class="pythonop">.</span>get(url, params<span class="pythonop">=</span>{ &quot;data&quot; : text })
 
-    <span style="color: #008800; font-weight: bold">if</span> response<span style="color: #333333">.</span>ok:
-        responseData <span style="color: #333333">=</span> response<span style="color: #333333">.</span>json()
-        topMatch <span style="color: #333333">=</span> responseData[<span style="color: #0000DD; font-weight: bold">0</span>]
-        <span style="color: #008800; font-weight: bold">return</span> topMatch
-    <span style="color: #008800; font-weight: bold">else</span>:
-        response<span style="color: #333333">.</span>raise_for_status()
-
-
-<span style="color: #888888"># CHANGE THIS to something you want your machine learning model to classify</span>
-demo <span style="color: #333333">=</span> classify(<span style="background-color: #fff0f0">&quot;The text that you want to test&quot;</span>)
-
-label <span style="color: #333333">=</span> demo[&quot;class_name&quot;]
-confidence <span style="color: #333333">=</span> demo[&quot;confidence&quot;]
+    <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
+        responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
+        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        <span class="pythonfunc">return</span> topMatch
+    <span class="pythonfunc">else</span>:
+        response<span class="pythonop">.</span>raise_for_status()
 
 
-<span style="color: #888888"># CHANGE THIS to do something different with the result</span>
-<span style="color: #008800; font-weight: bold">print</span> (&quot;result: &#39;%s&#39; with %d%% confidence&quot; <span style="color: #333333">%</span> (label, confidence))
+<span class="pythoncomments"># CHANGE THIS to something you want your machine learning model to classify</span>
+demo <span class="pythonop">=</span> classify(<span style="background-color: #fff0f0">&quot;<strong>{{ testdata.text }}</strong>&quot;</span>)
+
+label <span class="pythonop">=</span> demo[&quot;class_name&quot;]
+confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
+
+
+<span class="pythoncomments"># CHANGE THIS to do something different with the result</span>
+<span class="pythonfunc">print</span> (&quot;result: &#39;%s&#39; with %d%% confidence&quot; <span class="pythonop">%</span> (label, confidence))
+</pre></div>
+        </div>
+        <div class="modelguidance" ng-if="project.type === 'images' && testsource === 'local'">
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span>
+
+<span class="pythoncomments"># Gets the contents of an image file to be sent to the</span>
+<span class="pythoncomments"># machine learning model for classifying</span>
+<span class="pythonfunc">def</span> <span class="pythonfuncname">getImageFileData</span>(locationOfImageFile):
+    <span class="pythonfunc">with</span> <span style="color: #007020">open</span>(locationOfImageFile, &quot;rb&quot;) <span class="pythonfunc">as</span> f:
+        data <span class="pythonop">=</span> f<span class="pythonop">.</span>read()
+        <span class="pythonfunc">return</span> data<span class="pythonop">.</span>encode(&quot;base64&quot;)
+
+
+<span class="pythoncomments"># This function will pass your image to the machine learning model</span>
+<span class="pythoncomments"># and return the top result with the highest confidence</span>
+<span class="pythonfunc">def</span> <span class="pythonfuncname">classify</span>(imagefile):
+    key <span class="pythonop">=</span> &quot;9dcb8cf0-7655-11e7-bec6-4b6cfab7e9c1a914e139-e673-47a9-b442-dcef47e30012&quot;
+    url <span class="pythonop">=</span> &quot;https://machinelearningforkids.co.uk/api/scratch/&quot;<span class="pythonop">+</span> key <span class="pythonop">+</span> &quot;/classify&quot;
+
+    response <span class="pythonop">=</span> requests<span class="pythonop">.</span>post(url, json<span class="pythonop">=</span>{ &quot;data&quot; : getImageFileData(imagefile) })
+
+    <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
+        responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
+        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        <span class="pythonfunc">return</span> topMatch
+    <span class="pythonfunc">else</span>:
+        response<span class="pythonop">.</span>raise_for_status()
+
+
+<span class="pythoncomments"># CHANGE THIS to the name of the image file you want to classify</span>
+demo <span class="pythonop">=</span> classify(<span style="background-color: #fff0f0;">&quot;<strong>{{ testdata.imagefile }}</strong>&quot;</span>)
+
+label <span class="pythonop">=</span> demo[&quot;class_name&quot;]
+confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
+
+
+<span class="pythoncomments"># CHANGE THIS to do something different with the result</span>
+<span class="pythonfunc">print</span> (&quot;result: &#39;<span style="background-color: #eeeeee">%s</span>&#39; with <span style="background-color: #eeeeee">%d%%</span> confidence&quot; <span class="pythonop">%</span> (label, confidence))
+</pre></div>
+        </div>
+        <div class="modelguidance" ng-if="project.type === 'images' && testsource === 'web'">
+<div class="pythoncodebox"><pre class="pythoncode"><span class="pythonfunc">import</span> <span style="pythonimport">requests</span><span class="pythonop">,</span> <span style="pythonimport">base64</span>
+
+<span class="pythoncomments"># Gets the contents of an image on the Internet to be</span>
+<span class="pythoncomments"># sent to the machine learning model for classifying</span>
+<span class="pythonfunc">def</span> <span class="pythonfuncname">getImageUrlData</span>(wwwLocationOfImage):
+    <span class="pythonfunc">return</span> base64<span class="pythonop">.</span>b64encode(requests<span class="pythonop">.</span>get(wwwLocationOfImage)<span class="pythonop">.</span>content)
+
+
+<span class="pythoncomments"># This function will pass your image to the machine learning model</span>
+<span class="pythoncomments"># and return the top result with the highest confidence</span>
+<span class="pythonfunc">def</span> <span class="pythonfuncname">classify</span>(imageurl):
+    key <span class="pythonop">=</span> &quot;{{ scratchkey.id }}&quot;
+    url <span class="pythonop">=</span> &quot;https://machinelearningforkids.co.uk/api/scratch/&quot;<span class="pythonop">+</span> key <span class="pythonop">+</span> &quot;/classify&quot;
+
+    response <span class="pythonop">=</span> requests<span class="pythonop">.</span>post(url, json<span class="pythonop">=</span>{ &quot;data&quot; : getImageUrlData(imageurl) })
+
+    <span class="pythonfunc">if</span> response<span class="pythonop">.</span>ok:
+        responseData <span class="pythonop">=</span> response<span class="pythonop">.</span>json()
+        topMatch <span class="pythonop">=</span> responseData[<span style="pythonint">0</span>]
+        <span class="pythonfunc">return</span> topMatch
+    <span class="pythonfunc">else</span>:
+        response<span class="pythonop">.</span>raise_for_status()
+
+
+<span class="pythoncomments"># CHANGE THIS to the URL of the image you want to classify</span>
+demo <span class="pythonop">=</span> classify(<span style="background-color: #fff0f0">&quot;<strong>{{ testdata.imageurl }}</strong>&quot;</span>)
+
+label <span class="pythonop">=</span> demo[&quot;class_name&quot;]
+confidence <span class="pythonop">=</span> demo[&quot;confidence&quot;]
+
+
+<span class="pythoncomments"># CHANGE THIS to do something different with the result</span>
+<span class="pythonfunc">print</span> (&quot;result: &#39;<span style="background-color: #eeeeee">%s</span>&#39; with <span style="background-color: #eeeeee">%d%%</span> confidence&quot; <span class="pythonop">%</span> (label, confidence))
 </pre></div>
         </div>
     </div>

--- a/src/lib/restapi/scratch.ts
+++ b/src/lib/restapi/scratch.ts
@@ -76,6 +76,9 @@ async function classifyWithScratchKey(req: Express.Request, res: Express.Respons
         if (err.message === 'Missing data') {
             return res.status(httpstatus.BAD_REQUEST).jsonp({ error : 'Missing data' });
         }
+        if (err.message === 'Unexpected response when retrieving credentials for Scratch') {
+            return res.status(httpstatus.NOT_FOUND).jsonp({ error : 'Scratch key not found' });
+        }
 
         log.error({ err }, 'Classify error');
         return res.status(httpstatus.INTERNAL_SERVER_ERROR).jsonp(err);


### PR DESCRIPTION
This is the start of a new page that demonstrates how to drive the
Scratch Keys API from Python code.

The idea is to make this an alternative option for older students who
might find Scratch too simplistic or limiting.

This PR enables Python projects for text and images projects only.

I'm using Angular binding to allow students to customize the data that
the Python code should submit to the classifier, with the sample code
updating live.

Sample code for images comes in two flavours - classifying a local
image file or classifying an image from the Internet.

I haven't done numbers projects because I haven't found a way to cover
multi-choice and numeric values in a way that is simple and easy to
follow.

I also need at least one worksheet to show how this could be used
before this issue can be closed.

Contributes to: #11 

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>