### PR TITLE
chore: Verify Object Store bucket exists at startup

### DIFF
--- a/src/lib/imagestore/bulkdelete.ts
+++ b/src/lib/imagestore/bulkdelete.ts
@@ -4,7 +4,6 @@ import * as IBMCosSDK from 'ibm-cos-sdk';
 import * as keys from './keys';
 // type definitions
 import * as Types from './types';
-import { getImage } from './index';
 
 
 

--- a/src/lib/imagestore/index.ts
+++ b/src/lib/imagestore/index.ts
@@ -40,6 +40,8 @@ export function init(): void {
     else {
         throw new Error('Missing OBJECT_STORE_CREDS');
     }
+
+    verifyBucket();
 }
 
 
@@ -118,5 +120,21 @@ function getImageObject(key: string, response: IBMCosSDK.S3.GetObjectOutput): Ty
         etag : response.ETag,
         filetype : getImageType(key, response),
     };
+}
+
+
+
+function verifyBucket(): void {
+    const req: IBMCosSDK.S3.ListObjectsRequest = {
+        Bucket: BUCKET,
+        MaxKeys: 1,
+    };
+
+    cos.listObjects(req, (err: IBMCosSDK.AWSError, output: IBMCosSDK.S3.ListObjectsOutput) => {
+        if (err) {
+            log.error({ err }, 'Unable to query Object Storage');
+            throw new Error('Failed to verify Object Store config : ' + err.message);
+        }
+    });
 }
 

--- a/src/lib/imagestore/index.ts
+++ b/src/lib/imagestore/index.ts
@@ -130,7 +130,7 @@ function verifyBucket(): void {
         MaxKeys: 1,
     };
 
-    cos.listObjects(req, (err: IBMCosSDK.AWSError, output: IBMCosSDK.S3.ListObjectsOutput) => {
+    cos.listObjects(req, (err: IBMCosSDK.AWSError/*, output: IBMCosSDK.S3.ListObjectsOutput*/) => {
         if (err) {
             log.error({ err }, 'Unable to query Object Storage');
             throw new Error('Failed to verify Object Store config : ' + err.message);

--- a/src/lib/imagestore/keys.ts
+++ b/src/lib/imagestore/keys.ts
@@ -1,5 +1,4 @@
 // local dependency
-import * as Types from './types';
 import { ImageSpec, ProjectSpec, UserSpec, ClassSpec } from './types';
 
 export const SEPARATOR = '/';


### PR DESCRIPTION
This commit will throw an uncaught exception at startup if we can't
query the object store bucket for keys.

Closes: #19

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>