### PR TITLE
chore: Update allowance for free VR API keys

### DIFF
--- a/src/lib/restapi/users.ts
+++ b/src/lib/restapi/users.ts
@@ -201,7 +201,7 @@ async function getPolicy(req: Express.Request, res: Express.Response) {
             isManaged : policy.isManaged,
 
             maxTextModels : availableTextCredentials * 20,
-            maxImageModels : availableImageCredentials * 1,
+            maxImageModels : availableImageCredentials * 2,
 
             maxUsers : policy.maxUsers,
             supportedProjectTypes : policy.supportedProjectTypes,


### PR DESCRIPTION
A free tier VR API key now allows two machine learning models, where it
used to allow 1. This commit updates the sum that is used to display
the number of allowed models to match this new allowance.

Contributes to: #20

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>