### PR TITLE
fix: Protect against project names that cannot be stored

### DIFF
--- a/src/lib/db/objects.ts
+++ b/src/lib/db/objects.ts
@@ -129,6 +129,12 @@ const MULTICHOICES_CHOICE_LABEL_MAXLENGTH = 9;
 
 const IS_VALID_CHOICE = /^[^0-9\-.,][^,]*$/;
 
+/**
+ * Limit project names to 1-36 ASCII characters - everything
+ * between a space (ASCII code 32) to a black square (ASCII code 254)
+ */
+export const VALID_PROJECT_NAME = /^[ -■]{1,36}$/;
+
 
 export function createNumberProjectField(
     userid: string, classid: string, projectid: string,

--- a/src/lib/restapi/projects.ts
+++ b/src/lib/restapi/projects.ts
@@ -5,6 +5,7 @@ import * as httpstatus from 'http-status';
 import * as auth from './auth';
 import * as store from '../db/store';
 import * as Objects from '../db/db-types';
+import * as dbobjects from '../db/objects';
 import * as users from '../auth0/users';
 import * as Users from '../auth0/auth-types';
 import * as urls from './urls';
@@ -87,6 +88,10 @@ async function createProject(req: Express.Request, res: Express.Response) {
     if (!req.body || !req.body.type || !req.body.name) {
         return res.status(httpstatus.BAD_REQUEST)
                   .send({ error : 'Missing required field' });
+    }
+    if (dbobjects.VALID_PROJECT_NAME.test(req.body.name) === false) {
+        return res.status(httpstatus.BAD_REQUEST)
+                  .send({ error : 'Invalid project name' });
     }
     if (req.body.type === 'text' && !req.body.language) {
         return res.status(httpstatus.BAD_REQUEST)

--- a/src/tests/restapi/projects.ts
+++ b/src/tests/restapi/projects.ts
@@ -360,6 +360,24 @@ describe('REST API - projects', () => {
     describe('createProject()', () => {
 
 
+        it('should reject names that cannot be stored by MySQL using "utf8"', () => {
+            const studentId = uuid();
+
+            const url = '/api/classes/' + TESTCLASS + '/students/' + studentId + '/projects';
+
+            nextAuth0UserId = studentId;
+            nextAuth0UserTenant = TESTCLASS;
+
+            return request(testServer)
+                .post(url)
+                .send({ name : '⚽', type : 'text' })
+                .expect('Content-Type', /json/)
+                .expect(httpstatus.BAD_REQUEST)
+                .then((err) => {
+                    assert.equal(err.body.error, 'Invalid project name');
+                });
+        });
+
         it('should respect tenant policies on project types', () => {
             const studentId = uuid();
 


### PR DESCRIPTION
Project names are stored using MySQL's 'utf8' data type, which isn't
true UTF-8, but a smaller subset that doesn't include longer (in bytes)
characters.

This meant longer UTF-8 characters like emoji cannot be stored.

The two main approaches to fixing this are either to switch to a
different MySQL type (e.g. utf8mb4) or to use input validation to
restrict the new-project requests to a tolerable subset.

I've gone with the latter. It's enough of a character range to include
accented characters, so I don't think it will cause any multilingual
problems. And I don't mind not allowing projects to be named with
emojis.

Closes: #58

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>