### PR TITLE
feat: Scratch 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 trash
 public/scratchx
+public/scratch3
 node_modules
 coverage
 logs/*.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,6 +64,10 @@ gulp.task('scratchxinstall', ['crossdomain'], function() {
     return gulp.src('public/scratchx/**').pipe(gulp.dest('web/scratchx'));
 });
 
+gulp.task('scratch3install', ['crossdomain'], function() {
+    return gulp.src('public/scratch3/**').pipe(gulp.dest('web/scratch3alpha'));
+});
+
 gulp.task('datasets', function() {
     return gulp.src('public/datasets/**').pipe(gulp.dest('web/datasets'));
 });
@@ -176,7 +180,7 @@ gulp.task('test', () => {
         .pipe(mocha(mochaOptions));
 });
 
-gulp.task('web', ['css', 'minifyjs', 'images', 'html', 'angularcomponents', 'languages', 'datasets', 'scratchxinstall']);
+gulp.task('web', ['css', 'minifyjs', 'images', 'html', 'angularcomponents', 'languages', 'datasets', 'scratchxinstall', 'scratch3install']);
 gulp.task('build', ['web', 'compile']);
 
 gulp.task('default', sequence('build', 'lint', 'test'));
@@ -185,6 +189,6 @@ gulp.task('default', sequence('build', 'lint', 'test'));
 gulp.task('buildprod', sequence(
     'clean',
     'bower',
-    ['css', 'minifyprodjs', 'images', 'prodhtml', 'angularcomponents', 'languages', 'datasets', 'scratchxinstall'],
+    ['css', 'minifyprodjs', 'images', 'prodhtml', 'angularcomponents', 'languages', 'datasets', 'scratchxinstall', 'scratch3install'],
     'compile',
     'lint'));

--- a/public/app.js
+++ b/public/app.js
@@ -151,6 +151,12 @@
                 templateUrl: 'static/components-<%= VERSION %>/scratch/scratch.html',
                 controllerAs: 'vm'
             })
+            .state('mlproject_scratch3', {
+                url: '/mlproject/:userId/:projectId/scratch3',
+                controller: 'Scratch3Controller',
+                templateUrl: 'static/components-<%= VERSION %>/scratch3/scratch3.html',
+                controllerAs: 'vm'
+            })
             .state('mlproject_python', {
                 url: '/mlproject/:userId/:projectId/python',
                 controller: 'PythonController',

--- a/public/components/mlproject/mlproject.html
+++ b/public/components/mlproject/mlproject.html
@@ -52,7 +52,7 @@
             <div class="menucontainer" >
                 <div class="mlprojectmenu">
                     <div class="mlprojectmenutitle" translate="PROJECT.PYTHON.TITLE"></div>
-                    <div class="mlprojectmenudescription"><span class="badge">Beta</span> <span translate="PROJECT.PYTHON.BODY"></span></div>
+                    <div class="mlprojectmenudescription" translate="PROJECT.PYTHON.BODY"></div>
                     <div class="mlprojectmenubutton">
                         <button type="button" class="btn btn-primary"
                                 ui-sref="mlproject_python({ projectId : projectId, userId : userId })"
@@ -66,6 +66,15 @@
                         <button type="button" class="btn btn-primary"
                                 ng-click="vm.appInventor($event)"
                                 translate="PROJECT.APPINVENTOR.TITLE"></button>
+                    </div>
+                </div>
+                <div class="mlprojectmenu" ng-if="project.type === 'text'">
+                    <div class="mlprojectmenutitle" translate="PROJECT.SCRATCH3.TITLE"></div>
+                    <div class="mlprojectmenudescription"><span class="badge">Early Alpha</span> <span translate="PROJECT.SCRATCH3.BODY"></span></div>
+                    <div class="mlprojectmenubutton">
+                        <button type="button" class="btn btn-primary"
+                                ui-sref="mlproject_scratch3({ projectId : projectId, userId : userId })"
+                                translate="PROJECT.SCRATCH3.TITLE"></button>
                     </div>
                 </div>
             </div>

--- a/public/components/python/python.html
+++ b/public/components/python/python.html
@@ -31,10 +31,6 @@
 
     <div ng-if="projectId && !project" class="loading"> </div>
 
-    <div ng-if="project" class="alert alert-warning pageheadermsg" role="alert" style="margin-top: 1em">
-        <strong>Warning:</strong> This is a beta feature. Please <a href="mailto:dale.lane@uk.ibm.com">let me know</a> if you find any problems with it.
-    </div>
-
     <div ng-if="project && project.labels.length <= 1" class="modelguidancecontainer">
         <div class="modelguidance">
             <div class="modelstatusdetail">

--- a/public/components/scratch3/scratch3.controller.js
+++ b/public/components/scratch3/scratch3.controller.js
@@ -1,0 +1,62 @@
+    (function () {
+
+        angular
+            .module('app')
+            .controller('Scratch3Controller', Scratch3Controller);
+
+        Scratch3Controller.$inject = [
+            'authService', 'projectsService', 'scratchkeysService',
+            '$stateParams', '$scope'
+        ];
+
+        function Scratch3Controller(authService, projectsService, scratchkeysService, $stateParams, $scope) {
+
+            var vm = this;
+            vm.authService = authService;
+
+            var alertId = 1;
+            vm.errors = [];
+            vm.warnings = [];
+            vm.dismissAlert = function (type, errIdx) {
+                vm[type].splice(errIdx, 1);
+            };
+            function displayAlert(type, errObj) {
+                if (!errObj) {
+                    errObj = {};
+                }
+                vm[type].push({ alertid : alertId++, message : errObj.message || errObj.error || 'Unknown error', status : errObj.status });
+            }
+
+            $scope.projectId = $stateParams.projectId;
+            $scope.userId = $stateParams.userId;
+
+            authService.getProfileDeferred()
+                .then(function (profile) {
+                    vm.profile = profile;
+
+                    return projectsService.getProject($scope.projectId, $scope.userId, profile.tenant);
+                })
+                .then(function (project) {
+                    $scope.project = project;
+
+                    if (project.type === 'text') {
+                        return scratchkeysService.getScratchKeys(project.id, $scope.userId, vm.profile.tenant);
+                    }
+                })
+                .then(function (resp) {
+                    if (resp) {
+                        var scratchkey = resp[0];
+
+                        scratchkey.extensionurl = window.location.origin +
+                                                '/api/scratch/' +
+                                                scratchkey.id +
+                                                '/extension3.js'
+
+                        $scope.scratchkey = scratchkey;
+                    }
+                })
+                .catch(function (err) {
+                    displayAlert('errors', err.data);
+                });
+        }
+    }());

--- a/public/components/scratch3/scratch3.html
+++ b/public/components/scratch3/scratch3.html
@@ -1,0 +1,84 @@
+<div ng-if="!isAuthenticated">
+    <div class="alert alert-warning pageheadermsg">
+        <strong>Not logged in</strong>
+    </div>
+    <div class="text-center">
+        <button class="btn btn-primary" ng-click="vm.authService.login()">Log In</button>
+    </div>
+</div>
+
+<div ng-if="isAuthenticated && !projectId" class="alert alert-danger pageheadermsg">
+    <strong>Error:</strong> Missing project id. Go back to <a ui-sref="projects">your projects</a>
+</div>
+
+<div ng-if="isAuthenticated && projectId">
+    <div class="jumbotron">
+        <h2 class="text-center">Using machine learning in Scratch 3</h2>
+    </div>
+    <div class="backbutton">
+        <a ui-sref="mlproject({ projectId : projectId, userId : userId  })">&lt; Back to project</a>
+    </div>
+
+    <div ng-repeat="error in vm.errors" class="alert alert-danger alert-dismissible pageheadermsg" role="alert" ng-click="vm.dismissAlert('errors', $index)">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Error:</strong> {{ error.message }}<br/>
+        <em ng-if="error.status >= 500">If this keeps happening, please <a ui-sref="help">let me know</a>.</em>
+    </div>
+    <div ng-repeat="warning in vm.warnings" class="alert alert-warning alert-dismissible pageheadermsg" role="alert" ng-click="vm.dismissAlert('warnings', $index)">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Warning:</strong> {{ warning.message }}
+    </div>
+
+    <div ng-if="projectId && !project && !scratchkey" class="loading"> </div>
+
+    <div ng-if="project" class="alert alert-warning pageheadermsg" role="alert" style="margin-top: 1em">
+        <strong>Warning:</strong> This is a very, very early alpha. That means I've just started building support for Scratch 3. It's not finished, and will have lots of bugs and problems.
+    </div>
+
+    <div ng-if="project && project.labels.length <= 1" class="modelguidancecontainer">
+        <div class="modelguidance">
+            <div class="modelstatusdetail">
+                Your project isn't ready to be used in Scratch yet.
+            </div>
+            <div class="modelstatusdetail">
+                Or go to the <a ui-sref="mlproject_models({ projectId : projectId, userId : userId })">Learn &amp; Test</a>
+                page for some tips on what to do next.
+            </div>
+        </div>
+    </div>
+
+    <div ng-if="project && project.type !== 'text'" style="margin: 2em;">
+        Scratch 3 is only working with text models at the moment.
+    </div>
+
+    <div ng-if="scratchkey && project.type === 'text'" class="modelguidancecontainer">
+        <div class="modelguidance">
+            <div class="modelstatusdetail">
+                Have you heard about Scratch 3?
+            </div>
+            <div class="modelstatusdetail">
+                Scratch 3 is the new version of Scratch and is coming soon. For more information, read
+                <a href="https://medium.com/scratchteam-blog/3-things-to-know-about-scratch-3-0-18ee2f564278">3 Things To Know About Scratch 3.0</a>
+            </div>
+            <div class="modelstatusdetail">
+                I'm working on updating Machine Learning for Kids to work with Scratch 3, and this
+                page is here to give you an early glimpse at what that might be like.
+            </div>
+        </div>
+        <div class="modelguidance">
+            <div class="modelstatusdetail">
+                Please be patient. It's going to be several weeks before this is properly
+                finished, so for now, assume that it's going to be a bit broken, unfinished, and
+                buggy.
+            </div>
+            <div class="modelstatusdetail">
+                But if you'd like to give it a try, click the button below.
+            </div>
+            <div class="modelstatusdetail">
+                <a target="_blank" class="btn btn-default"
+                   href="/scratch3alpha?url={{ scratchkey.extensionurl }}">Open Scratch 3 (alpha)</a>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
             <nav class="navbar navbar-default">
                 <div class="container-fluid">
                     <div class="navbar-header">
-                        <a class="navbar-brand" ui-sref="welcome" style="padding-top: 5px"><img src="static/images/mlforkids-logo-small.jpg" style="border: thin grey solid"></a>
+                        <a class="navbar-brand" ui-sref="welcome" style="padding-top: 5px"><img src="static/images/mlforkids-logo-small.jpg" style="border: thin #c9c9c9 solid"></a>
                         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
                             <span class="sr-only">Toggle navigation</span>
                             <span class="icon-bar"></span>

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -105,6 +105,10 @@
         "APPINVENTOR": {
             "TITLE": "App Inventor",
             "BODY": "Make a mobile app that uses your machine learning model"
+        },
+        "SCRATCH3": {
+            "TITLE": "Scratch 3",
+            "BODY": "What Scratch 3 might look like with machine learning blocks"
         }
     },
     "TRAINING": {

--- a/resources/scratch3-text-classify.js
+++ b/resources/scratch3-text-classify.js
@@ -1,0 +1,262 @@
+class MachineLearningText {
+
+    constructor() {
+        this._labels = [
+            {{#labels}}
+            { value: '{{name}}' },
+            {{/labels}}
+        ];
+    }
+
+
+    getInfo() {
+        return {
+            // making the id unique to allow multiple instances
+            id: 'mlforkidstext' + Date.now(),
+            // the name of the student project
+            name: '{{{ projectname }}}',
+
+            //
+            colour: '#4B4A60',
+            colourSecondary: '#AFAEC4',
+            colourTertiary: '#96C896',
+
+            // Machine Learning for Kids site icon
+            menuIconURI: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCARXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAKgAgAEAAAAAQAAACigAwAEAAAAAQAAACgAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/iAqBJQ0NfUFJPRklMRQABAQAAApBsY21zBDAAAG1udHJSR0IgWFlaIAfhAAkAFAAWADEACWFjc3BBUFBMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD21gABAAAAANMtbGNtcwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2Rlc2MAAAEIAAAAOGNwcnQAAAFAAAAATnd0cHQAAAGQAAAAFGNoYWQAAAGkAAAALHJYWVoAAAHQAAAAFGJYWVoAAAHkAAAAFGdYWVoAAAH4AAAAFHJUUkMAAAIMAAAAIGdUUkMAAAIsAAAAIGJUUkMAAAJMAAAAIGNocm0AAAJsAAAAJG1sdWMAAAAAAAAAAQAAAAxlblVTAAAAHAAAABwAcwBSAEcAQgAgAGIAdQBpAGwAdAAtAGkAbgAAbWx1YwAAAAAAAAABAAAADGVuVVMAAAAyAAAAHABOAG8AIABjAG8AcAB5AHIAaQBnAGgAdAAsACAAdQBzAGUAIABmAHIAZQBlAGwAeQAAAABYWVogAAAAAAAA9tYAAQAAAADTLXNmMzIAAAAAAAEMSgAABeP///MqAAAHmwAA/Yf///ui///9owAAA9gAAMCUWFlaIAAAAAAAAG+UAAA47gAAA5BYWVogAAAAAAAAJJ0AAA+DAAC2vlhZWiAAAAAAAABipQAAt5AAABjecGFyYQAAAAAAAwAAAAJmZgAA8qcAAA1ZAAAT0AAACltwYXJhAAAAAAADAAAAAmZmAADypwAADVkAABPQAAAKW3BhcmEAAAAAAAMAAAACZmYAAPKnAAANWQAAE9AAAApbY2hybQAAAAAAAwAAAACj1wAAVHsAAEzNAACZmgAAJmYAAA9c/8IAEQgAKAAoAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAMCBAEFAAYHCAkKC//EAMMQAAEDAwIEAwQGBAcGBAgGcwECAAMRBBIhBTETIhAGQVEyFGFxIweBIJFCFaFSM7EkYjAWwXLRQ5I0ggjhU0AlYxc18JNzolBEsoPxJlQ2ZJR0wmDShKMYcOInRTdls1V1pJXDhfLTRnaA40dWZrQJChkaKCkqODk6SElKV1hZWmdoaWp3eHl6hoeIiYqQlpeYmZqgpaanqKmqsLW2t7i5usDExcbHyMnK0NTV1tfY2drg5OXm5+jp6vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAQIAAwQFBgcICQoL/8QAwxEAAgIBAwMDAgMFAgUCBASHAQACEQMQEiEEIDFBEwUwIjJRFEAGMyNhQhVxUjSBUCSRoUOxFgdiNVPw0SVgwUThcvEXgmM2cCZFVJInotIICQoYGRooKSo3ODk6RkdISUpVVldYWVpkZWZnaGlqc3R1dnd4eXqAg4SFhoeIiYqQk5SVlpeYmZqgo6SlpqeoqaqwsrO0tba3uLm6wMLDxMXGx8jJytDT1NXW19jZ2uDi4+Tl5ufo6ery8/T19vf4+fr/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh7/2gAMAwEAAhEDEQAAAfZWzkFaHAKPtqbAzcghZXUum7gTWXOiyI51NXW1f//aAAgBAQABBQJ9SpMVtGQk7I/fP+/vKQqKbnPK6qhNxkVSJMteRzFqX/wIkVjPM6LB63jJkcyzzFH/2gAIAQMRAT8B+j//2gAIAQIRAT8B+j//2gAIAQEABj8CagF0A+D/AHh/BlJVXTuv7O3+T2VjjQGmrKkqiFfUF45RZVpwLKlGI/KrTljQmmjmoaGvFxjIjBWK/iX/AJX9TjqqgoWj+01dAUCa8X+6T/hPPEe1wr8HrEk/5TTVAABrxf8A/8QAMxABAAMAAgICAgIDAQEAAAILAREAITFBUWFxgZGhscHw0RDh8SAwQFBgcICQoLDA0OD/2gAIAQEAAT8hrNQhAC//ADlUEsXiP+/o/wBv+HL4fz/whjuBseUCRHF/gVURPmhZiAQFgo+QNQV+KOuKZqD/AAPG3+i4RISSwN/h0HnKKP8AVn7k/wCIvnnXpx4v83v/ABSKGU7/AKv/2gAMAwEAAhEDEQAAEKmvFfd3jnv/xAAzEQEBAQADAAECBQUBAQABAQkBABEhMRBBUWEgcfCRgaGx0cHh8TBAUGBwgJCgsMDQ4P/aAAgBAxEBPxD/AOP/2gAIAQIRAT8QPQ9222//2gAIAQEAAT8QqmwqCVmdfj/l6RYzJQynX/f8b4/4/wAd5f8AAQ8NoYBnPmmHSIsy2RPNifBw91n2nIp5soUBXZWebCDNaCR3fiy4dEwtDJUnAwZMID5P5Cv+b3pAkdSgiK5Uf5jUS2DwECEl4u878nl59q+D7f2SntLxFRBCcRMfmjoDCaAcCv/Z',
+
+            // blocks to add to the new section
+            blocks: [
+                // classify the text and return the label
+                {
+                    opcode: 'label',
+                    blockType: Scratch.BlockType.REPORTER,
+                    text: 'recognise text [TEXT] (label)',
+                    arguments: {
+                        TEXT: {
+                            type: Scratch.ArgumentType.STRING,
+                            defaultValue: 'text'
+                        }
+                    }
+                },
+
+                // classify the text and return the confidence score
+                {
+                    opcode: 'confidence',
+                    blockType: Scratch.BlockType.REPORTER,
+                    text: 'recognise text [TEXT] (confidence)',
+                    arguments: {
+                        TEXT: {
+                            type: Scratch.ArgumentType.STRING,
+                            defaultValue: 'text'
+                        }
+                    }
+                },
+
+                // provide blocks representing each of the labels
+                {{#labels}}
+                {
+                    opcode: 'return_label_{{idx}}',
+                    blockType: Scratch.BlockType.REPORTER,
+                    text: '{{name}}'
+                },
+                {{/labels}}
+
+                // add training data to the project
+                {
+                    opcode: 'addTraining',
+                    blockType: Scratch.BlockType.COMMAND,
+                    text: 'add training data [TEXT] [LABEL]',
+                    arguments: {
+                        TEXT: {
+                            type: Scratch.ArgumentType.STRING,
+                            defaultValue: 'text'
+                        },
+                        LABEL: {
+                            type: Scratch.ArgumentType.STRING,
+                            defaultValue: 'label'
+                            // BUG: This seems to break the rendering
+                            //  of the Scratch palette
+                            // menu: 'labels'
+                        }
+                    }
+                }
+            ],
+
+            menus: {
+                labels: this._labels
+            }
+        };
+    }
+
+
+    label({ TEXT }) {
+        return new Promise(resolve => getTextClassificationResponse(TEXT, TEXT, 'class_name', resolve));
+    }
+    confidence({ TEXT }) {
+        return new Promise(resolve => getTextClassificationResponse(TEXT, TEXT, 'confidence', resolve));
+    }
+
+
+    {{#labels}}
+    return_label_{{idx}} () {
+        return '{{name}}';
+    }
+    {{/labels}}
+
+
+    addTraining({ TEXT, LABEL }) {
+        var url = new URL('{{{ storeurl }}}');
+        url.searchParams.append('data', TEXT);
+        url.searchParams.append('label', LABEL);
+
+        var options = {
+            body: {
+                data: TEXT,
+                label: LABEL
+            }
+        };
+
+        return fetch(url, options)
+            .then((response) => {
+                if (response.status !== 200) {
+                    return response.json();
+                }
+            })
+            .then((responseJson) => {
+                if (responseJson) {
+                    console.log(responseJson);
+                }
+            });
+    }
+}
+
+
+
+var resultsCache = {
+    // schema for objects in this cache:
+    //
+    // cacheKey (text to be classified) : {
+    //
+    //    // returned by the API
+    //    class_name : topClassName,
+    //    confidence : topClassConfidence,
+    //    classifierTimestamp : isoStringDateTime,
+    //
+    //    // added locally
+    //    fetched : timestamp-ms-since-epoch
+    // }
+};
+
+
+
+var TEN_SECONDS = 10 * 1000;
+
+
+
+
+// returns the current date in the format that the API uses
+function nowAsString() {
+    return new Date().toISOString();
+}
+// returns true if the provided timestamp is within the last 10 seconds
+function veryRecently(timestamp) {
+    return (timestamp + TEN_SECONDS) > Date.now();
+}
+
+
+
+
+
+// Submit xhr request to the classify API to get a label for a string
+function classifyText(text, cacheKey, lastmodified, callback) {
+    var url = new URL('{{{ classifyurl }}}');
+    url.searchParams.append('data', text);
+
+    var options = {
+        headers : {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+
+            'If-Modified-Since': lastmodified
+        }
+    };
+
+    return fetch(url, options)
+        .then((response) => {
+            if (response.status === 304 && resultsCache[cacheKey]) {
+                // the API returned NOT-MODIFIED so we'll
+                // reuse the value we got last time
+                callback(resultsCache[cacheKey]);
+            }
+            else if (response.status === 200) {
+                response.json().then((responseJson) => {
+                    if (responseJson && responseJson.length > 0) {
+                        // we got a result from the classifier
+                        callback(responseJson[0]);
+                    }
+                    else {
+                        callback({
+                            class_name: 'Unknown',
+                            confidence: 0,
+                            classifierTimestamp: nowAsString()
+                        });
+                    }
+                });
+            }
+            else {
+                console.log(err);
+
+                callback({
+                    class_name: 'Unknown',
+                    confidence: 0,
+                    classifierTimestamp: nowAsString()
+                });
+            }
+        });
+        // .catch((err) => {
+
+        // });
+}
+
+
+function getTextClassificationResponse(text, cacheKey, valueToReturn, callback) {
+    var cached = resultsCache[cacheKey];
+
+    // protect against kids putting the ML block inside a forever
+    //  loop making too many requests too quickly
+    // this throttling means we won't try and classify the same
+    //  string more than once every 10 seconds
+    if (cached && cached.fetched && veryRecently(cached.fetched)) {
+        return callback(cached[valueToReturn]);
+    }
+
+    // if we have a cached value, get it's timestamp
+    var lastmodified = nowAsString();
+    if (cached && cached.classifierTimestamp) {
+        lastmodified = cached.classifierTimestamp;
+    }
+
+    // submit to the classify API
+    classifyText(text, cacheKey, lastmodified, function (result) {
+        if (result.random) {
+            // We got a randomly selected result (which means we must not
+            //  have a working classifier) but we thought we had a model
+            //  with a good status.
+            // This should not be possible - we've gotten into a weird
+            //  unexpected state.
+            return callback(result[valueToReturn]);
+        }
+
+        // update the timestamp to allow local throttling
+        result.fetched = Date.now();
+
+        // cache the result to let it be used again
+        resultsCache[cacheKey] = result;
+
+        // return the requested value from the response
+        callback(result[valueToReturn]);
+    });
+}
+
+
+Scratch.extensions.register(new MachineLearningText());

--- a/src/lib/restapi/config.ts
+++ b/src/lib/restapi/config.ts
@@ -49,6 +49,9 @@ export function setupUI(app: express.Application): void {
     const scratchxlocation: string = path.join(__dirname, '/../../../web/scratchx');
     app.use('/scratchx', compression(), express.static(scratchxlocation, { maxAge : constants.ONE_WEEK }));
 
+    const scratch3alpha: string = path.join(__dirname, '/../../../web/scratch3alpha');
+    app.use('/scratch3alpha', compression(), express.static(scratch3alpha, { maxAge : constants.ONE_WEEK }));
+
     const datasetslocation: string = path.join(__dirname, '/../../../web/datasets');
     app.use('/datasets', compression(), express.static(datasetslocation, { maxAge : constants.ONE_WEEK }));
 

--- a/src/lib/restapi/scratch.ts
+++ b/src/lib/restapi/scratch.ts
@@ -152,7 +152,8 @@ async function storeTrainingData(req: Express.Request, res: Express.Response) {
 
 
 
-async function getScratchxExtension(req: Express.Request, res: Express.Response) {
+
+async function getExtension(req: Express.Request, res: Express.Response, version: 2 | 3) {
     const apikey = req.params.scratchkey;
 
     try {
@@ -166,7 +167,7 @@ async function getScratchxExtension(req: Express.Request, res: Express.Response)
             project.fields = await store.getNumberProjectFields(project.userid, project.classid, project.id);
         }
 
-        const extension = await extensions.getScratchxExtension(scratchKey, project);
+        const extension = await extensions.getScratchxExtension(scratchKey, project, version);
         return res.set('Content-Type', 'application/javascript')
                   .set(headers.NO_CACHE)
                   .send(extension);
@@ -177,7 +178,12 @@ async function getScratchxExtension(req: Express.Request, res: Express.Response)
 }
 
 
-
+function getScratchxExtension(req: Express.Request, res: Express.Response) {
+    getExtension(req, res, 2);
+}
+function getScratch3Extension(req: Express.Request, res: Express.Response) {
+    getExtension(req, res, 3);
+}
 
 
 async function getScratchxStatus(req: Express.Request, res: Express.Response) {
@@ -210,5 +216,6 @@ export default function registerApis(app: Express.Application) {
     app.get(urls.SCRATCHKEY_TRAIN, storeTrainingData);
 
     app.get(urls.SCRATCHKEY_EXTENSION, getScratchxExtension);
+    app.get(urls.SCRATCH3_EXTENSION, getScratch3Extension);
     app.get(urls.SCRATCHKEY_STATUS, getScratchxStatus);
 }

--- a/src/lib/restapi/urls.ts
+++ b/src/lib/restapi/urls.ts
@@ -48,6 +48,7 @@ export const SCRATCHKEY_TRAIN      = '/api/scratch/:scratchkey/train';
 export const SCRATCHKEY_CLASSIFY   = '/api/scratch/:scratchkey/classify';
 export const SCRATCHKEY_STATUS     = '/api/scratch/:scratchkey/status';
 export const SCRATCHKEY_EXTENSION  = '/api/scratch/:scratchkey/extension.js';
+export const SCRATCH3_EXTENSION    = '/api/scratch/:scratchkey/extension3.js';
 
 //
 // URLs about session users

--- a/src/lib/scratchx/extensions.ts
+++ b/src/lib/scratchx/extensions.ts
@@ -1,5 +1,4 @@
 // external dependencies
-import * as fs from 'fs';
 import * as Mustache from 'mustache';
 // local dependencies
 import * as Types from '../db/db-types';
@@ -14,8 +13,11 @@ function escapeProjectName(name: string): string {
     return name.replace(/'/g, '\\\'');
 }
 
-async function getTextExtension(scratchkey: Types.ScratchKey, project: Types.Project): Promise<string> {
-    const template: string = await fileutils.read('./resources/scratchx-text-classify.js');
+async function getTextExtension(scratchkey: Types.ScratchKey, project: Types.Project, version: 2 | 3): Promise<string> {
+    const template: string = await fileutils.read(
+        version === 3 ? './resources/scratch3-text-classify.js' :
+                        './resources/scratchx-text-classify.js');
+
     Mustache.parse(template);
     const rendered = Mustache.render(template, {
         statusurl : ROOT_URL + '/api/scratch/' + scratchkey.id + '/status',
@@ -89,10 +91,15 @@ async function getNumbersExtension(scratchkey: Types.ScratchKey, project: Types.
 
 
 
-export function getScratchxExtension(scratchkey: Types.ScratchKey, project: Types.Project): Promise<string> {
+export function getScratchxExtension(
+    scratchkey: Types.ScratchKey,
+    project: Types.Project,
+    version: 2 | 3,
+): Promise<string>
+{
     switch (scratchkey.type) {
     case 'text':
-        return getTextExtension(scratchkey, project);
+        return getTextExtension(scratchkey, project, version);
     case 'images':
         return getImagesExtension(scratchkey, project);
     case 'numbers':

--- a/src/tests/scratchx/extensions.ts
+++ b/src/tests/scratchx/extensions.ts
@@ -31,7 +31,7 @@ describe('Scratchx - status', () => {
                 isCrowdSourced : false,
             };
 
-            const extension = await extensions.getScratchxExtension(key, proj);
+            const extension = await extensions.getScratchxExtension(key, proj, 2);
 
             assert(extension.indexOf('/api/scratch/' + key.id + '/status') > 0);
             assert(extension.indexOf('/api/scratch/' + key.id + '/classify') > 0);
@@ -68,7 +68,7 @@ describe('Scratchx - status', () => {
                 isCrowdSourced : false,
             };
 
-            const extension = await extensions.getScratchxExtension(key, proj);
+            const extension = await extensions.getScratchxExtension(key, proj, 2);
 
             assert(extension.indexOf('/api/scratch/' + key.id + '/status') > 0);
             assert(extension.indexOf('/api/scratch/' + key.id + '/classify') > 0);
@@ -118,7 +118,7 @@ describe('Scratchx - status', () => {
                 isCrowdSourced : false,
             };
 
-            const extension = await extensions.getScratchxExtension(key, proj);
+            const extension = await extensions.getScratchxExtension(key, proj, 2);
 
             assert(extension.indexOf('/api/scratch/' + key.id + '/status') > 0);
             assert(extension.indexOf('/api/scratch/' + key.id + '/classify') > 0);
@@ -180,7 +180,7 @@ describe('Scratchx - status', () => {
                 isCrowdSourced : false,
             };
 
-            const extension = await extensions.getScratchxExtension(key, proj);
+            const extension = await extensions.getScratchxExtension(key, proj, 2);
 
             assert(extension.indexOf('/api/scratch/' + key.id + '/status') > 0);
             assert(extension.indexOf('/api/scratch/' + key.id + '/classify') > 0);


### PR DESCRIPTION
Initial implementation of a Scratch 3 extension. Only the text extension
is implemented so far, as it's the simplest of the three.

It's functional enough to be used, so it's shown in the UI - although
clearly marked as an early alpha.

Almost all of the functionality from the Scratch 2 version (e.g. caching,
throttling, support for getting labels and confidence scores, ability to
add training data, etc.) is present.

The only thing missing is the status indicator, which doesn't seem to be
included in the Scratch 3 UI. It means there's no clear way to show
whether the machine learning model is ready / functional.

Contributes to: #21

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>