### PR TITLE
feat: Display confirmation when verifying email addresses

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,7 +6,6 @@
 
     config.$inject = [
         '$stateProvider',
-        '$locationProvider',
         'lockProvider',
         '$urlRouterProvider',
         'jwtOptionsProvider',
@@ -14,7 +13,7 @@
         '$translateProvider'
     ];
 
-    function config($stateProvider, $locationProvider, lockProvider, $urlRouterProvider, jwtOptionsProvider, $httpProvider, $translateProvider) {
+    function config($stateProvider, lockProvider, $urlRouterProvider, jwtOptionsProvider, $httpProvider, $translateProvider) {
 
         $stateProvider
             .state('home', {
@@ -265,5 +264,5 @@
                 return lang;
             })
             .fallbackLanguage('en');
-        }
+    }
 })();

--- a/public/app.run.js
+++ b/public/app.run.js
@@ -23,5 +23,9 @@
         // send them back to the login screen if they get an HTTP 401
         //  from an API call
         authManager.redirectWhenUnauthenticated();
+
+        // display confirmation if the user is verifying their
+        //  email address with Auth0
+        authService.verifyEmail();
     }
 })();

--- a/public/bower.json
+++ b/public/bower.json
@@ -12,16 +12,16 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "1.7.2",
-    "angular-animate": "1.7.2",
-    "angular-aria": "1.7.2",
+    "angular": "1.7.3",
+    "angular-animate": "1.7.3",
+    "angular-aria": "1.7.3",
     "angular-jwt": "0.1.10",
     "angular-material": "1.1.10",
-    "angular-messages": "1.7.2",
+    "angular-messages": "1.7.3",
     "angular-moment": "1.2.0",
     "angular-scroll": "1.0.2",
-    "angular-sanitize": "1.7.2",
-    "angular-ui-router": "1.0.18",
+    "angular-sanitize": "1.7.3",
+    "angular-ui-router": "1.0.20",
     "angular-translate": "2.18.1",
     "angular-translate-loader-static-files": "2.18.1",
     "angular-lock": "3.0.1",
@@ -33,6 +33,6 @@
     "jquery": "3.3.1"
   },
   "resolutions": {
-    "angular": "1.7.2"
+    "angular": "1.7.3"
   }
 }

--- a/public/components/auth/auth.service.js
+++ b/public/components/auth/auth.service.js
@@ -7,13 +7,15 @@
     authService.$inject = [
         'lock', 'authManager',
         '$q', '$http',
+        '$mdDialog',
         '$rootScope',
+        '$window',
         '$state',
         '$timeout'
     ];
 
 
-    function authService(lock, authManager, $q, $http, $rootScope, $state, $timeout) {
+    function authService(lock, authManager, $q, $http, $mdDialog, $rootScope, $window, $state, $timeout) {
 
         var SESSION_USERS_CLASS = 'session-users';
 
@@ -298,6 +300,30 @@
         }
 
 
+        function verifyEmail() {
+            var paramStr = $window.location.search;
+            if (paramStr &&
+                paramStr[0] === '?')
+            {
+                var params = {};
+                var paramsAry = paramStr.substr(1).split('&').forEach(function (str) {
+                    var pair = str.split('=');
+                    params[pair[0]] = pair[1];
+                });
+
+                if (params.message === 'Your%20email%20was%20verified.%20You%20can%20continue%20using%20the%20application.') {
+                    var alert = $mdDialog.alert()
+                                    .title('Welcome to Machine Learning for Kids')
+                                    .textContent('Your email address has been verified.')
+                                    .ok('OK');
+                    $mdDialog.show(alert).finally(function () {
+                        window.location = '/';
+                    });
+                }
+            }
+        }
+
+
 
         return {
             login: login,
@@ -308,7 +334,9 @@
             getProfileDeferred: getProfileDeferred,
             isAuthenticated : isAuthenticated,
 
-            createSessionUser : createSessionUser
+            createSessionUser : createSessionUser,
+
+            verifyEmail : verifyEmail
         };
     }
 })();


### PR DESCRIPTION
When users click the Verify Email Address link they get in an email, it
will go first to auth0.com, and then redirect to
machinelearningforkids.co.uk with a query parameter confirming the
outcome.

This commit looks for that query parameter and displays a dialog if
found to let the user know that it worked.

It uses `window.location` to send the user to the home page while clearing
the query parameter to prevent it being displayed again.

Closes: #9

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>