### PR TITLE
fix: Handle accidental drops outside of training buckets

### DIFF
--- a/public/components/training/ignoreDrop.directive.js
+++ b/public/components/training/ignoreDrop.directive.js
@@ -1,0 +1,38 @@
+(function () {
+
+    angular
+        .module('app')
+        .directive('ignoreDrop', ignoreDrop);
+
+    /* Students sometimes miss when dragging images into a training bucket for */
+    /* handling by mlImageLoader, and accidentally drop the image just outside */
+    /* the bucket. This is handled by the browser's default behaviour, which   */
+    /* is to navigate to the URL for the dropped image. This has caused        */
+    /* confusion in several classes as students don't understand why they've   */
+    /* lost their page, or that they need to click 'Back' to return to their   */
+    /* training work.                                                          */
+    /*                                                                         */
+    /* This directive is a way to handle this by capturing and swallowing      */
+    /* drag and drop events on divs that hold the training buckets.            */
+
+    function ignoreDrop() {
+
+        function cancel(evt) {
+            if (evt && evt.preventDefault) {
+                evt.preventDefault();
+            }
+            return false;
+        }
+
+        function link (scope, jqlElements, attrs) {
+            var jqlElement = jqlElements[0];
+
+            jqlElement.addEventListener('drop', cancel);
+            jqlElement.addEventListener('dragover', cancel);
+        }
+
+        return {
+            link : link
+        };
+    }
+}());

--- a/public/components/training/training.html
+++ b/public/components/training/training.html
@@ -6,7 +6,7 @@
         <button class="btn btn-primary" ng-click="vm.authService.login()" translate="APP.LOGIN"></button>
     </div>
 </div>
-<div ng-if="isAuthenticated">
+<div ng-if="isAuthenticated" ignore-drop>
     <div class="jumbotron training">
         <h2 class="text-center" ng-if="!project" translate="TRAINING.TITLE"></h2>
         <div class="mlprojectdescription" ng-if="project">


### PR DESCRIPTION
This adds a new directive that swallows drag-and-drop events to prevent
browser navigation from accidental drops outside of a training bucket.

Closes: #87

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>