### PR TITLE
fix: CSS fix for canvas on Internet Explorer

### DIFF
--- a/public/components/mlcanvas/mlcanvas.css
+++ b/public/components/mlcanvas/mlcanvas.css
@@ -13,6 +13,7 @@
     cursor: crosshair;
 
     flex: 1;
+    -ms-flex: 1 0 auto;
 }
 
 .mlcanvas .canvastools {
@@ -21,6 +22,7 @@
     padding: 1em;
 
     flex: 1;
+    -ms-flex: 1 0 auto;
 }
 
 .mlcanvas {


### PR DESCRIPTION
Flex seems to have different defaults on Internet Explorer than on
any other browser. Because of course it does.

Added some IE-specific CSS to get IE to mirror the behaviour of
the other browsers.

Closes: #112

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>