### PR TITLE
feat: Improve buckets on mobile

### DIFF
--- a/public/components/training/training.css
+++ b/public/components/training/training.css
@@ -17,6 +17,17 @@
     min-height: 200px;
 }
 
+@media (max-width: 550px) {
+    .trainingbuckets {
+        height: initial;
+        background-color: white; 
+    }
+
+    .trainingbuckets, .trainingbucket {
+        display: block;
+    }
+}
+
 .trainingbucket {
     flex: 1;
     flex-grow: 1;

--- a/public/components/training/training.css
+++ b/public/components/training/training.css
@@ -17,19 +17,6 @@
     min-height: 200px;
 }
 
-@media (max-width: 550px) {
-    .trainingbuckets {
-        height: initial;
-        background-color: white;
-    }
-    .trainingbuckets, .trainingbucket {
-        display: block;
-    }
-    .trainingbucket {
-        margin-top: 4rem;
-    }
-}
-
 .trainingbucket {
     flex: 1;
     flex-grow: 1;
@@ -43,6 +30,19 @@
     display: flex;
     flex-direction: column;
     position: relative;
+}
+
+@media (max-width: 550px) {
+    .trainingbuckets {
+        height: initial;
+        background-color: white;
+    }
+    .trainingbuckets, .trainingbucket {
+        display: block;
+    }
+    .trainingbucket {
+        margin-top: 4rem;
+    }
 }
 
 .loadingtraining {

--- a/public/components/training/training.css
+++ b/public/components/training/training.css
@@ -20,11 +20,13 @@
 @media (max-width: 550px) {
     .trainingbuckets {
         height: initial;
-        background-color: white; 
+        background-color: white;
     }
-
     .trainingbuckets, .trainingbucket {
         display: block;
+    }
+    .trainingbucket {
+        margin-top: 4rem;
     }
 }
 


### PR DESCRIPTION
For mobile, make the buckets a bit easier to read. Because scrolling is easy on mobile, just render all of the buckets at their full height. 

If you'd rather a max height on each bucket, just set the height/max-height property in the css. If going for a max height, I'd recommend `100vh`