### PR TITLE
fix: Add support for Watson Assistant instances in Tokyo

### DIFF
--- a/src/lib/training/conversation.ts
+++ b/src/lib/training/conversation.ts
@@ -530,6 +530,7 @@ export async function identifyRegion(username: string, password: string): Promis
         'https://gateway-wdc.watsonplatform.net/assistant/api',
         'https://gateway-syd.watsonplatform.net/assistant/api',
         'https://gateway-fra.watsonplatform.net/assistant/api',
+        'https://gateway-tok.watsonplatform.net/assistant/api',
         'https://gateway.watsonplatform.net/conversation/api',
     ];
 


### PR DESCRIPTION
There is a new IBM Cloud region hosting Watson Assistant now, so
I need to add the URL for it to the site. This will enable
credentials created in that region to be used.

Closes: #133

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>