### PR TITLE
Add info about data sent to IBM services in help

### DIFF
--- a/public/components/help/help.html
+++ b/public/components/help/help.html
@@ -376,6 +376,9 @@
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-7"></p>
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-8"></p>
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-9"></p>
+                    <p><strong translate="HELP.ACCOUNTISSUES.Q4-A-10"></strong></p>
+                    <p translate="HELP.ACCOUNTISSUES.Q4-A-11"></p>
+                    <p translate="HELP.ACCOUNTISSUES.Q4-A-12"></p>
                 </div>
             </div>
         </div>

--- a/public/components/help/help.html
+++ b/public/components/help/help.html
@@ -376,9 +376,9 @@
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-7"></p>
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-8"></p>
                     <p translate="HELP.ACCOUNTISSUES.Q4-A-9"></p>
-                    <p><strong translate="HELP.ACCOUNTISSUES.Q4-A-10"></strong></p>
-                    <p translate="HELP.ACCOUNTISSUES.Q4-A-11"></p>
-                    <p translate="HELP.ACCOUNTISSUES.Q4-A-12"></p>
+                    <p><strong translate="HELP.ACCOUNTISSUES.Q5-A-1"></strong></p>
+                    <p translate="HELP.ACCOUNTISSUES.Q5-A-1"></p>
+                    <p translate="HELP.ACCOUNTISSUES.Q5-A-2"></p>
                 </div>
             </div>
         </div>

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -1007,7 +1007,10 @@
             "Q4-A-6": "General information stored about all accounts",
             "Q4-A-7": "User management for Machine Learning for Kids is implemented using the third party service, <a href='https://auth0.com/'>Auth0</a>. They store the IP address that you last logged into Machine Learning for Kids from, and the type of browser you used. I've never found a reason to use that, but it is stored if I did want to go and look for it.",
             "Q4-A-8": "Errors that happen in the web browser are captured using the third party service, <a href='https://sentry.io/'>Sentry</a>. If something goes wrong, it will capture information about the error, including your username, IP address, type of browser you were using, and a technical description of what went wrong.",
-            "Q4-A-9": "I use <a href='https://www.google.com/analytics/'>Google Analytics</a> so that I know how many users visit Machine Learning for Kids each day. Although it captures information such as geographic location and browser type, this is only ever displayed to me in an anonymised aggregate way."
+            "Q4-A-9": "I use <a href='https://www.google.com/analytics/'>Google Analytics</a> so that I know how many users visit Machine Learning for Kids each day. Although it captures information such as geographic location and browser type, this is only ever displayed to me in an anonymised aggregate way.",
+            "Q4-A-10": "What data is sent to IBM services?",
+            "Q5-A-11": "Different activities and lessons use different services, and each of these have different data collection, retention and privacy policies.",
+            "Q5-A-12": "Projects with recognizing text send data to IBM's Watson Assistant service.  This project uses `X-Watson-Learning-Opt-Out` to opt-out of data collection (see <a href='https://cloud.ibm.com/apidocs/assistant#data-collection'>data collection</a> for more).  For more details, including guidelines on sharing data with this service, see <a href='https://cloud.ibm.com/docs/services/assistant?topic=assistant-information-security#information-security'>information security</a>."
         }
     }
 }


### PR DESCRIPTION
This is trying to help out with https://github.com/IBM/taxinomitis/issues/172.

@dalelane As a first step, this updates the help in the bit I discovered looking at recognizing text, and IBM Watson Assistant.  I tried to run the app locally to grab a proper screenshot for ya but I don't have accounts for all the dependencies like Auth0 or Watson so wasn't sure what to do there.  Hopefully I've followed your example and this work just like it appears :)