### PR TITLE
fix: Switch URL index to a prefix index

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -64,7 +64,7 @@ CREATE TABLE imagetraining (
     isstored BOOLEAN DEFAULT false
 );
 
-CREATE INDEX imagetraining_getImageTraining on imagetraining(projectid, label, imageurl);
+CREATE INDEX imagetraining_getImageTraining on imagetraining(projectid, label, imageurl(250));
 CREATE INDEX imagetraining_getTrainingLabels on imagetraining(projectid);
 
 


### PR DESCRIPTION
Indexing the whole imageurl column in the imagetraining table was
causing problems for two developers. My best guess is that the
character set they have as a default has wider characters than
what I'm using, resulting in the index exceeding MySQL default
limits.

In hindsight, indexing the whole column is excessive. Looking at
the data in the current production site, 90% of the rows have a
imageurl that is 250 characters or fewer, so I think a prefix
index will be sufficient. (Not only will it hopefully resolve
the error reported, I think it should be more efficient).

Contributes to: #225

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>