### PR TITLE
feat: Make numbers ML models more deterministic

### DIFF
--- a/serverless-functions/mltraining-numbers/numbers.py
+++ b/serverless-functions/mltraining-numbers/numbers.py
@@ -42,7 +42,7 @@ def main():
 
     # building decision tree classifier
     vec = DictVectorizer(sparse=False)
-    dt = tree.DecisionTreeClassifier()
+    dt = tree.DecisionTreeClassifier(random_state=42)
     dt.fit(vec.fit_transform(examples), labels)
 
     # creating decision tree visualization


### PR DESCRIPTION
The library I'm using to build decision tree classifiers has a random
element to how it performs splits during training. This means two
students using the same training data might see different results.
Or a student who retrains their model without making changes to their
training data might see different results.

In the interest of avoiding potential confusion this might cause,
this commit introduces a fixed seed to make it more deterministic.

I've picked a seed of 42 because it is the ultimate answer. :-)

Closes: #229

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>