### PR TITLE
feat: Use App Inventor to train ML models

### DIFF
--- a/public/components/appinventor/appinventor.controller.js
+++ b/public/components/appinventor/appinventor.controller.js
@@ -17,6 +17,12 @@
         $scope.projectId = $stateParams.projectId;
         $scope.userId = $stateParams.userId;
 
+        $scope.projecturls = {
+            appinventor : 'http://ai2.appinventor.mit.edu/',
+            train : '/#!/mlproject/' + $stateParams.userId + '/' + $stateParams.projectId + '/training',
+            learnandtest : '/#!/mlproject/' + $stateParams.userId + '/' + $stateParams.projectId + '/models'
+        };
+
         authService.getProfileDeferred()
             .then(function (profile) {
                 vm.profile = profile;
@@ -25,6 +31,9 @@
             })
             .then(function (project) {
                 $scope.project = project;
+
+                $scope.projecturls.train = '/#!/mlproject/' + $scope.project.userid + '/' + $scope.project.id + '/training';
+                $scope.projecturls.learnandtest = '/#!/mlproject/' + $scope.project.userid + '/' + $scope.project.id + '/models';
 
                 return scratchkeysService.getScratchKeys($stateParams.projectId, $stateParams.userId, vm.profile.tenant);
             })

--- a/public/components/appinventor/appinventor.html
+++ b/public/components/appinventor/appinventor.html
@@ -24,32 +24,74 @@
         <a ui-sref="mlproject({ projectId : projectId, userId : userId  })" translate="APP.BACKTOPROJECT"></a>
     </div>
 
+    <!-- ------------------------------------- -->
+    <!--  page state :   LOADING               -->
+    <!--                                       -->
+    <!-- waiting to get info about the project -->
+    <!-- ------------------------------------- -->
     <div ng-if="projectId && !scratchkey" class="loading"> </div>
 
+
+    <!-- ------------------------------------- -->
+    <!--  page state :   SOUNDS                -->
+    <!--                                       -->
+    <!-- AppInventor can't be used with sounds -->
+    <!-- ------------------------------------- -->
     <div ng-if="project && project.type === 'sounds'" class="modelguidancecontainer">
         <div class="modelguidance">
             App Inventor cannot be used with sounds projects.
         </div>
     </div>
 
+
+    <!-- ------------------------------------- -->
+    <!--  page state :   ONE LABEL             -->
+    <!--                                       -->
+    <!-- there is only one training bucket so  -->
+    <!--  we can't do anything until we have   -->
+    <!--  at least one more                    -->
+    <!-- ------------------------------------- -->
     <div ng-if="project && project.labels.length <= 1 && project.type !== 'sounds'" class="modelguidancecontainer">
         <div class="modelguidance">
             <div class="modelstatusdetail" translate="APPINVENTOR.NOTREADY"></div>
-            <div class="modelstatusdetail">
-                Or go to the <a ui-sref="mlproject_models({ projectId : projectId, userId : userId })" translate="PROJECT.LEARNANDTEST.TITLE"></a>
-                page for some tips on what to do next.
+            <div class="modelstatusdetail" translate="APPINVENTOR.LAUNCH_APPINVENTOR_BY_ITSELF" translate-values='{ "url" : projecturls.appinventor }'></div>
+            <div class="modelstatusdetail" translate="SCRATCH.GO_TO_LEARNANDTEST" translate-values='{ urls : projecturls }'></div>
+        </div>
+    </div>
+
+
+    <div ng-if="scratchkey && project && project.labels.length > 1 && project.type !== 'sounds'" 
+         style="margin: 2em;">
+        <!-- ------------------------------------- -->
+        <!--  page state :   NO MODEL              -->
+        <!--                                       -->
+        <!-- no model but we could use             -->
+        <!--  App Inventor to create one           -->
+        <!-- ------------------------------------- -->
+        <div ng-if="!scratchkey.model">
+            <div class="alert alert-info" role="alert" translate="SCRATCH.NOMODEL"></div>
+            <div>
+                You can <strong><a href="" ui-sref="mlproject_models({ projectId : projectId, userId : userId })">train one now</a></strong> and then come back to start your App Inventor project.
             </div>
+            <div>
+                Or you can go to <a class="btn btn-default" target="_blank" href="{{ projecturls.appinventor }}">App Inventor</a> now.
+            </div>    
+        </div>
+
+        <!-- ------------------------------------- -->
+        <!--  page state :   MODEL                 -->
+        <!--                                       -->
+        <!-- machine learning model is ready to go -->
+        <!-- ------------------------------------- -->
+        <div ng-if="scratchkey.model">
+            <a target="_blank" class="btn btn-primary"
+               href="{{ projecturls.appinventor }}"
+               translate="APPINVENTOR.LAUNCH"></a>
         </div>
     </div>
 
-    <div ng-if="project && project.labels.length > 1 && scratchkey && !scratchkey.model  && project.type !== 'sounds'" style="margin: 2em;">
-        <div class="alert alert-info" role="alert" translate="APPINVENTOR.NOMODEL"></div>
-        <div>
-            You can <strong><a href="" ui-sref="mlproject_models({ projectId : projectId, userId : userId })">train one now</a></strong> and then come back to start your App Inventor project.
-        </div>
-    </div>
-
-    <div ng-if="project && project.labels.length > 1 && scratchkey && scratchkey.model  && project.type !== 'sounds'"
+    
+    <div ng-if="project && project.labels.length > 1 && project.type !== 'sounds'"
          class="modelguidancecontainer">
 
         <div class="modelguidance">
@@ -78,10 +120,6 @@
             <!-- <img src="static/images/appinventor.png" alt="App Inventor" style="width: 100%; border: thin #c9c9c9 solid;"/> -->
         </div>
         <div class="modelguidance">
-            <div class="modelstatusdetail">
-                To use <strong>App Inventor</strong>, go to
-                <a href="http://ai2.appinventor.mit.edu/">http://ai2.appinventor.mit.edu</a>
-            </div>
             <div class="modelstatusdetail">
                 To add your machine learning model to your App Inventor project:
                 <ol>

--- a/public/components/scratch3/scratch3.html
+++ b/public/components/scratch3/scratch3.html
@@ -25,8 +25,21 @@
         <a ui-sref="mlproject({ projectId : projectId, userId : userId  })" translate="APP.BACKTOPROJECT"></a>
     </div>
 
+    <!-- ------------------------------------- -->
+    <!--  page state :   LOADING               -->
+    <!--                                       -->
+    <!-- waiting to get info about the project -->
+    <!-- ------------------------------------- -->
     <div ng-if="projectId && !project && !scratchkey" class="loading"> </div>
 
+
+    <!-- ------------------------------------- -->
+    <!--  page state :   ONE LABEL             -->
+    <!--                                       -->
+    <!-- there is only one training bucket so  -->
+    <!--  we can't do anything until we have   -->
+    <!--  at least one more                    -->
+    <!-- ------------------------------------- -->
     <div ng-if="project && project.labels.length <= 1" class="modelguidancecontainer">
         <div class="modelguidance">
             <div class="modelstatusdetail" translate="SCRATCH.NOTREADY"></div>
@@ -36,7 +49,14 @@
     </div>
 
 
-    <div ng-if="scratchkey && project && project.labels.length > 1" style="margin: 2em;">
+    <div ng-if="scratchkey && project && project.labels.length > 1" 
+         style="margin: 2em;">
+        <!-- ------------------------------------- -->
+        <!--  page state :   NO MODEL              -->
+        <!--                                       -->
+        <!-- no model but we could use Scratch to  -->
+        <!--  create one                           -->
+        <!-- ------------------------------------- -->
         <div ng-if="!scratchkey.model">
             <div class="alert alert-info" role="alert" translate="SCRATCH.NOMODEL"></div>
             <div>
@@ -46,6 +66,12 @@
                 Or you can go <a class="btn btn-default" target="_blank" href="/scratch3?url={{ scratchkey.extensionurl }}">straight into Scratch</a> now.
             </div>
         </div>
+
+        <!-- ------------------------------------- -->
+        <!--  page state :   MODEL                 -->
+        <!--                                       -->
+        <!-- machine learning model is ready to go -->
+        <!-- ------------------------------------- -->
         <div ng-if="scratchkey.model">
             <a target="_blank" class="btn btn-primary"
                href="/scratch3?url={{ scratchkey.extensionurl }}"

--- a/public/languages/cs.json
+++ b/public/languages/cs.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Using machine learning in App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Your project isn't ready to be used in App Inventor yet.",
-        "NOMODEL": "You haven't trained a machine learning model yet."
+        "NOMODEL": "You haven't trained a machine learning model yet.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Using machine learning in Scratch",

--- a/public/languages/de.json
+++ b/public/languages/de.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Verwende Machine Learning im App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Dein Projekt kann noch nicht im App Inventor verwendet werden.",
-        "NOMODEL": "Du hast noch kein Machine Learning Model trainiert."
+        "NOMODEL": "Du hast noch kein Machine Learning Model trainiert.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Nutze Machine Learning in Scratch",

--- a/public/languages/el.json
+++ b/public/languages/el.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Χρησιμοποιώντας μηχανική μάθηση στο App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Το έργο σου δεν είναι ακόμα έτοιμο για χρήση στο App Inventor.",
-        "NOMODEL": "Δεν έχεις εκπαιδεύσει ακόμα ένα μοντέλο μηχανικής μάθησης."
+        "NOMODEL": "Δεν έχεις εκπαιδεύσει ακόμα ένα μοντέλο μηχανικής μάθησης.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Χρησιμοποιώντας μηχανική μάθηση στο Scratch",

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Using machine learning in App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Your project isn't ready to be used in App Inventor yet.",
-        "NOMODEL": "You haven't trained a machine learning model yet."
+        "NOMODEL": "You haven't trained a machine learning model yet.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Using machine learning in Scratch",

--- a/public/languages/es.json
+++ b/public/languages/es.json
@@ -565,8 +565,12 @@
 	"APPINVENTOR": {
 		"TITLE": "Usando aprendizaje automático en App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
 		"NOTREADY": "Tu Proyecto no está listo para usarse en App Inventor yet.",
-		"NOMODEL": "Todavia no has entrenado un modelo."
+		"NOMODEL": "Todavia no has entrenado un modelo.",
+
+        "LAUNCH": "Open App Inventor"
 	},
 	"SCRATCH": {
 		"TITLE": "Usando aprendizaje automático en Scratch",

--- a/public/languages/fr.json
+++ b/public/languages/fr.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Utilisation de l'apprentissage automatique dans App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Votre projet n'est pas encore prêt à être utilisé dans App Inventor.",
-        "NOMODEL": "Vous n'avez pas encore entraîné un modèle d'apprentissage machine."
+        "NOMODEL": "Vous n'avez pas encore entraîné un modèle d'apprentissage machine.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Utilisation de l'apprentissage machine dans Scratch",

--- a/public/languages/it.json
+++ b/public/languages/it.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Using machine learning in App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Your project isn't ready to be used in App Inventor yet.",
-        "NOMODEL": "You haven't trained a machine learning model yet."
+        "NOMODEL": "You haven't trained a machine learning model yet.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Using machine learning in Scratch",

--- a/public/languages/ja.json
+++ b/public/languages/ja.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "App Inventorで機械学習を使う",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "あなたのプレジェクトはまだ、App Inventorで使う準備ができていません。",
-        "NOMODEL": "まだ、機械学習モデルをトレーニングしていません。"
+        "NOMODEL": "まだ、機械学習モデルをトレーニングしていません。",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Scratchで機械学習を使う",

--- a/public/languages/ko.json
+++ b/public/languages/ko.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "앱 인벤터에서 머신러닝 사용하기",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "아직 준비중입니다",
-        "NOMODEL": "훈련된 모델이 없습니다"
+        "NOMODEL": "훈련된 모델이 없습니다",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "스크래치에서 머신러닝 사용하기",

--- a/public/languages/nl-be.json
+++ b/public/languages/nl-be.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Gebruik machine learning in App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Je project is nog niet klaar om in App Inventor te worden gebruikt.",
-        "NOMODEL": " Je hebt nog geen machine learning model getraind."
+        "NOMODEL": " Je hebt nog geen machine learning model getraind.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Gebruik machine learning in Scratch",

--- a/public/languages/pt-br.json
+++ b/public/languages/pt-br.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Usando aprendizado de máquina no App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Seu projeto ainda não está pronto para ser usado no App Inventor.",
-        "NOMODEL": "Você ainda não treinou um modelo de aprendizado de máquina."
+        "NOMODEL": "Você ainda não treinou um modelo de aprendizado de máquina.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Usando aprendizado de máquina no Scratch",

--- a/public/languages/si-lk.json
+++ b/public/languages/si-lk.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Using machine learning in App Inventor",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Your project isn't ready to be used in App Inventor yet.",
-        "NOMODEL": "You haven't trained a machine learning model yet."
+        "NOMODEL": "You haven't trained a machine learning model yet.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Using machine learning in Scratch",

--- a/public/languages/sv-se.json
+++ b/public/languages/sv-se.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "Att använda maskininlärning i App-uppfinnaren",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "Ditt projekt är inte klart att användas i App-uppfinnaren än.",
-        "NOMODEL": "Du har inte tränat en maskininlärningsmodell än."
+        "NOMODEL": "Du har inte tränat en maskininlärningsmodell än.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Att använda maskininlärning i Scratch",

--- a/public/languages/tr.json
+++ b/public/languages/tr.json
@@ -558,8 +558,11 @@
     },
     "APPINVENTOR": {
         "TITLE": "Uygulama Yaratıcısı'nda makine öğrenimini kullanma",
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
         "NOTREADY": "Projeniz henüz Uygulama Yaratıcısı’nda kullanılmaya hazır değil.",
-        "NOMODEL": " Henüz bir makine öğrenimi modelini eğitmediniz."
+        "NOMODEL": " Henüz bir makine öğrenimi modelini eğitmediniz.",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "Scratch'de makine öğrenimini kullanma",

--- a/public/languages/zh-cn.json
+++ b/public/languages/zh-cn.json
@@ -565,8 +565,12 @@
     "APPINVENTOR": {
         "TITLE": "在App Inventor中使用机器学习",
 
+        "LAUNCH_APPINVENTOR_BY_ITSELF": "(You can use <a href='{{ url }}' class='btn btn-default' target='_blank'>App Inventor by itself</a> if you want.)",
+
         "NOTREADY": "您的项目尚未准备好在App Inventor中使用。",
-        "NOMODEL": "你还没有训练过机器学习模型。"
+        "NOMODEL": "你还没有训练过机器学习模型。",
+
+        "LAUNCH": "Open App Inventor"
     },
     "SCRATCH": {
         "TITLE": "在Scratch中使用机器学习",


### PR DESCRIPTION
Now that the App Inventor extension has additional blocks
for collecting training data and training models, there
is no need to restrict the App Inventor extension to
projects with a trained model.

This commit reworks the App Inventor launch page to
provide options for projects still in progress.

Closes: #247

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>