### PR TITLE
fix: Create very large training zips locally

### DIFF
--- a/src/lib/utils/downloadAndZip.ts
+++ b/src/lib/utils/downloadAndZip.ts
@@ -383,30 +383,70 @@ export async function runInServerless(locations: ImageDownload[]): Promise<strin
 
             request.post(serverlessRequest)
             .on('error', (err) => {
-                log.error({ err }, 'Failed to run function');
-                return reject(err);
+                const customError = err as any;
+                if (customError.rerun) {
+                    log.error({ err, numlocations : locations.length },
+                              'Unexpected failure to run CreateZip - running again locally');
+
+                    return runLocally(locations)
+                        .then((zippath) => {
+                            return resolve(zippath);
+                        })
+                        .catch((localerr) => {
+                            log.error({ localerr }, 'Failed to re-run locally');
+                            return reject(localerr);
+                        });
+                }
+                else {
+                    log.error({ err, numlocations : locations.length }, 'CreateZip failed');
+                    return reject(err);
+                }
             })
             .on('response', (resp) => {
                 if (resp.statusCode !== 200) {
-                    log.error({
+                    const errorInfo = {
                         numlocations : locations.length,
                         status : resp.statusCode,
                         errorobj : resp.headers['x-machinelearningforkids-error'],
                         body : resp.body,
-                    }, 'Error response from OpenWhisk');
+                    };
+
+                    log.error(errorInfo, 'Error response from OpenWhisk');
 
                     let functionError = new Error('Failed to create zip') as any;
                     const hdrs = resp.headers['x-machinelearningforkids-error'];
                     if (hdrs && typeof hdrs === 'string') {
+                        // The serverless function CreateZip failed to create a zip
+                        //  file, but this wasn't an expected failure - it has
+                        //  returned an explanation for why. (e.g. one of the sites
+                        //  hosting an image requested refused to allow it to be
+                        //  downloaded).
+                        //
+                        // This means there is nothing left to do except to inform
+                        //  the user that we can't create the training zip.
                         try {
                             const functionErrorInfo = JSON.parse(hdrs);
                             functionError = new Error(functionErrorInfo.error) as any;
                             functionError.location = functionErrorInfo.location;
                         }
                         catch (err) {
-                            log.error({ err }, 'Failed to parse function error');
+                            log.error({ err, hdrs }, 'Failed to parse function error');
                         }
                     }
+                    else {
+                        // An unexpected and unexplained failure to create a zip file.
+                        //
+                        // The most common reason for getting here is that the serverless function
+                        //  CreateZip created a zip file that is larger than the 5mb response
+                        //  payload limit that IBM Cloud Functions allows.
+                        //
+                        // This needs some significant redesign/restructuring to handle it, but
+                        //  for now, we'll just workaround the problem by handling these
+                        //  (fortunately rare) edge cases by building the zip outside of OpenWhisk.
+                        functionError.rerun = true;
+                    }
+
+                    log.error(functionError, 'Failed to run CreateZip');
                     return resp.destroy(functionError);
                 }
             })


### PR DESCRIPTION
The most common reason for failing to create training zip files in OpenWhisk
is that the serverless function CreateZip creates a zip file that is larger
than the 5mb response payload limit that IBM Cloud Functions allows.

This needs some significant redesign/restructuring to handle it, but for now,
we'll just workaround the problem by handling these (fortunately rare) edge
cases by building the zip outside of OpenWhisk.

This is only done for unexpected failures - if the OpenWhisk function returns
an error payload, we just use the error description in it.

Contributes to: #263

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>