### PR TITLE
feat: Support for Watson API keys provisioned in Seoul

### DIFF
--- a/src/lib/restapi/watsonapis.ts
+++ b/src/lib/restapi/watsonapis.ts
@@ -126,18 +126,22 @@ async function addCredentials(req: Express.Request, res: Express.Response) {
     //
     try {
         if (newCredentials.servicetype === 'conv') {
-            const workingUrl = await conversation.identifyRegion(newCredentials.username, newCredentials.password);
+            const workingUrl = await conversation.identifyRegion(newCredentials.username,
+                                                                 newCredentials.password);
             newCredentials.url = workingUrl;
         }
         else if (newCredentials.servicetype === 'visrec') {
-            await visualRecognition.getImageClassifiers(newCredentials);
+            const workingUrl = await visualRecognition.identifyRegion(newCredentials);
+            newCredentials.url = workingUrl;
         }
     }
     catch (err) {
         if (err.statusCode === httpstatus.UNAUTHORIZED ||
             err.statusCode === httpstatus.FORBIDDEN)
         {
-            return res.status(httpstatus.BAD_REQUEST).json({ error : 'Watson credentials could not be verified' });
+            return res.status(httpstatus.BAD_REQUEST).json({
+                error : 'Watson credentials could not be verified',
+            });
         }
         log.error({ err }, 'Failed to validate credentials');
         return errors.unknownError(res, err);

--- a/src/lib/training/conversation.ts
+++ b/src/lib/training/conversation.ts
@@ -556,6 +556,7 @@ export async function identifyRegion(username: string, password: string): Promis
         'https://gateway-fra.watsonplatform.net/assistant/api',
         'https://gateway-tok.watsonplatform.net/assistant/api',
         'https://gateway-lon.watsonplatform.net/assistant/api',
+        'https://gateway-seo.watsonplatform.net/assistant/api',
         'https://gateway.watsonplatform.net/conversation/api',
     ];
 

--- a/src/lib/training/visualrecognition.ts
+++ b/src/lib/training/visualrecognition.ts
@@ -810,6 +810,52 @@ export async function getImageClassifiers(
 
 
 
+/**
+ * An admin user has provided the credentials for a Visual Recognition service instance,
+ *  but we don't know which IBM Cloud region the service instance is from. This function
+ *  identifies the region (by trying the credentials in all known regions, and returning
+ *  the URL for the region that the credentials were not rejected in).
+ *
+ * @returns url - Promise that resolves to the URL that accepted the credentials
+ */
+export async function identifyRegion(credentials: TrainingObjects.BluemixCredentials): Promise<string>
+{
+    if (getType(credentials) === 'legacy') {
+        // legacy credentials only ever supported a single region, so
+        //  just check what we've been given
+        await getImageClassifiers(credentials);
+        return credentials.url;
+    }
+    else {
+        const POSSIBLE_URLS = [
+            'https://gateway.watsonplatform.net/visual-recognition/api',
+            'https://gateway-seo.watsonplatform.net/visual-recognition/api',
+        ];
+
+        const testRequest = await createBaseRequest(credentials);
+        testRequest.timeout = 10000;
+
+        let lastErr: Error = new Error('Failed to verify credentials');
+
+        for (const url of POSSIBLE_URLS) {
+            try {
+                log.debug({ url }, 'Testing Visual Recognition credentials');
+                await request.get(url + '/v3/classifiers', testRequest);
+
+                // if we're here, the credentials were accepted
+                return url;
+            }
+            catch (err) {
+                log.debug({ url, err }, 'Credentials rejected');
+                lastErr = err;
+            }
+        }
+
+        // if we're here, all URLs rejected the credentials
+        throw lastErr;
+    }
+}
+
 
 
 export async function cleanupExpiredClassifiers(): Promise<void[]>

--- a/src/tests/restapi/watsonapis.ts
+++ b/src/tests/restapi/watsonapis.ts
@@ -28,7 +28,7 @@ describe('REST API - Bluemix credentials', () => {
     let getClassStub: sinon.SinonStub<[string], Promise<Types.ClassTenant>>;
     let getTextClassifiersStub: sinon.SinonStub<[string, string], Promise<string>>;
     let getImageClassifiersStub: sinon.SinonStub<[TrainingTypes.BluemixCredentials],
-                                                 Promise<TrainingTypes.ClassifierSummary[]>>;
+                                                 Promise<string>>;
 
     function authNoOp(
         req: express.Request,
@@ -81,11 +81,10 @@ describe('REST API - Bluemix credentials', () => {
                 });
             });
         getImageClassifiersStub = sinon
-            .stub(visualrecognition, 'getImageClassifiers')
+            .stub(visualrecognition, 'identifyRegion')
             .callsFake((creds: TrainingTypes.BluemixCredentials) => {
                 if (creds.username + creds.password === VALID_APIKEY) {
-                    const placeholder: TrainingTypes.ClassifierSummary[] = [];
-                    return Promise.resolve(placeholder);
+                    return Promise.resolve(creds.url);
                 }
                 return Promise.reject({
                     statusCode : 403,


### PR DESCRIPTION
Watson service instances can now be created in the Seoul region.
This commit adds support for the Seoul API endpoints.

Closes: #272

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>