### PR TITLE
feat: Enable in-browser TensorFlow.js training for all users

### DIFF
--- a/public/components/help/help.html
+++ b/public/components/help/help.html
@@ -33,6 +33,53 @@
     <div class="intro" translate="HELP.FAQS.INTRO1"></div>
     <div class="intro" translate="HELP.FAQS.INTRO2"></div>
     <div class="intro" translate="HELP.FAQS.INTRO3"></div>
+    <h4 translate="HELP.PROJECTS.TITLE"></h4>
+    <div class="panel-group">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    <a data-toggle="collapse" href="#helpImgtfjs" target="_self" translate="HELP.PROJECTS.Q1"></a>
+                </h4>
+            </div>
+            <div id="helpImgtfjs" class="panel-collapse collapse">
+                <div class="panel-body">
+                    <p translate="HELP.PROJECTS.Q1-A-1"></p>
+                    <p translate="HELP.PROJECTS.Q1-A-2"></p>
+                    <p translate="HELP.PROJECTS.Q1-A-3"></p>
+                    <p translate="HELP.PROJECTS.Q1-A-4"></p>
+                    <p><ul>
+                        <li translate="HELP.PROJECTS.Q1-A-5"></li>
+                        <li translate="HELP.PROJECTS.Q1-A-6"></li>
+                        <li translate="HELP.PROJECTS.Q1-A-7"></li>
+                    </ul></p>
+                    <p translate="HELP.PROJECTS.Q1-A-8"></p>
+                    <p translate="HELP.PROJECTS.Q1-A-9"></p>
+                    <p><ul>
+                        <li translate="HELP.PROJECTS.Q1-A-10"></li>
+                        <li translate="HELP.PROJECTS.Q1-A-11"></li>
+                        <li translate="HELP.PROJECTS.Q1-A-12"></li>
+                    </ul></p>
+                    <p translate="HELP.PROJECTS.Q1-A-13"></p>
+                    <p translate="HELP.PROJECTS.Q1-A-14"></p>
+                </div>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    <a data-toggle="collapse" href="#helpImgtfjsChange" target="_self" translate="HELP.PROJECTS.Q2"></a>
+                </h4>
+            </div>
+            <div id="helpImgtfjsChange" class="panel-collapse collapse">
+                <div class="panel-body">
+                    <p translate="HELP.PROJECTS.Q2-A-1"></p>
+                    <p translate="HELP.PROJECTS.Q2-A-2"></p>
+                    <p translate="HELP.PROJECTS.Q2-A-3"></p>
+                    <p translate="HELP.PROJECTS.Q2-A-4"></p>
+                </div>
+            </div>
+        </div>
+    </div>
     <h4 translate="HELP.SCRATCH.TITLE"></h4>
     <div class="panel-group">
         <div class="panel panel-default">

--- a/public/components/mlproject/mlproject.html
+++ b/public/components/mlproject/mlproject.html
@@ -26,7 +26,7 @@
         </div>
         <div class="mlprojectmenu">
             <div class="mlprojectmenutitle" translate="PROJECT.LEARNANDTEST.TITLE"></div>
-            <div class="mlprojectmenudescription">{{ 'PROJECT.LEARNANDTEST.BODY' | translate }} {{ project.type }}</div>
+            <div class="mlprojectmenudescription">{{ 'PROJECT.LEARNANDTEST.BODY' | translate }} {{ project.type === 'imgtfjs' ? 'images' : project.type }}</div>
             <div class="mlprojectmenubutton">
                 <button type="button" class="btn btn-primary"
                         ui-sref="mlproject_models({ projectId : projectId, userId : userId })"
@@ -35,7 +35,10 @@
         </div>
         <div class="mlprojectmenuexpanded">
             <div class="mlprojectmenutitle" translate="PROJECT.MAKES.TITLE"></div>
-            <div class="mlprojectmenudescription" translate="PROJECT.MAKES.BODY"></div>
+            <div class="mlprojectmenudescription" translate="PROJECT.MAKES.BODY_SCRATCHONLY"
+                 ng-if="project.type === 'sounds' || project.type === 'imgtfjs'"></div>
+            <div class="mlprojectmenudescription" translate="PROJECT.MAKES.BODY"
+                 ng-if="project.type === 'text' || project.type === 'images'"></div>
             <div class="mlprojectmenubutton">
                 <button type="button" class="btn btn-primary"
                         ui-sref="mlproject_makes({ projectId : projectId, userId : userId })"

--- a/public/components/models/models.css
+++ b/public/components/models/models.css
@@ -162,6 +162,16 @@
 }
 
 
+.modelprojecttypechange {
+    font-size: 11px;
+    text-align: right;
+    flex-grow: 1;
+    margin-right: 20px;
+    color: #337ab7;
+    cursor: pointer;
+}
+
+
 .tooltipBody {
     height: auto !important;
     width: auto !important;

--- a/public/components/models/models.html
+++ b/public/components/models/models.html
@@ -13,8 +13,22 @@
     <div class="jumbotron">
         <h2 class="text-center" translate="MODELS.TITLE"></h2>
     </div>
-    <div class="backbutton">
-        <a ui-sref="mlproject({ projectId : projectId, userId : userId })" translate="APP.BACKTOPROJECT"></a>
+    <div class="backbutton" style="width: 100%; display: flex;">
+        <div style="">
+            <a ui-sref="mlproject({ projectId : projectId, userId : userId })" translate="APP.BACKTOPROJECT"></a>
+        </div>
+        <div class="modelprojecttypechange"
+             ng-click="vm.changeProjectType('imgtfjs')"
+             ng-if="owner && project && project.type === 'images'"
+             ng-hide="status === 'training' || submittingTrainingRequest || submittingDeleteRequest"
+             translate="MODELS.CHANGETYPE.IMGTFJS">
+        </div>
+        <div class="modelprojecttypechange"
+             ng-click="vm.changeProjectType('images')"
+             ng-if="owner && project && project.type === 'imgtfjs'"
+             ng-hide="status === 'training' || submittingTrainingRequest || submittingDeleteRequest"
+             translate="MODELS.CHANGETYPE.IMAGES">
+        </div>
     </div>
 
     <div ng-repeat="error in vm.errors"
@@ -319,7 +333,7 @@
     </div>
 
 
-    <div ng-if="status === 'ready'" class="trainingserversection">
+    <div ng-if="status === 'ready'" ng-hide="loading" class="trainingserversection">
         <div style="margin: 1em;" ng-if="project.type === 'text'" translate="MODELS.TESTING.INTRO.TEXT" ></div>
         <div style="margin: 1em;" ng-if="project.type === 'images' || project.type === 'imgtfjs'" translate="MODELS.TESTING.INTRO.IMAGES" ></div>
         <div style="margin: 1em;" ng-if="project.type === 'numbers'" translate="MODELS.TESTING.INTRO.NUMBERS" ></div>
@@ -352,14 +366,14 @@
                     <span translate="MODELS.TESTING.DRAWING"></span>
                 </div>
             </div>
-            <br ng-if="project.type === 'images'"/>
-            <input ng-if="project.type === 'images'"
+            <br ng-if="project.type === 'images' || project.type === 'imgtfjs'"/>
+            <input ng-if="project.type === 'images' || project.type === 'imgtfjs'"
                    style="margin-left: 2em; width: 70%"
                    type="text"
                    ng-model="testformData.testimageurl"
                    ng-required="true"
                    placeholder="Test with a web address for an image on the Internet">
-            <button ng-if="project.type === 'images'"
+            <button ng-if="project.type === 'images' || project.type === 'imgtfjs'"
                    class="btn btn-default"
                    type="submit"
                    ng-disabled="testform.$invalid"
@@ -450,7 +464,7 @@
             </table>
         </div>
 
-        <button ng-if="!loading && status !== 'training' && trainingdatastatus === 'data' && owner"
+        <button ng-if="!loading && status !== 'training' && trainingdatastatus === 'data' && (owner || project.type === 'imgtfjs')"
                 style="margin: 4em;"
                 class="btn btn-primary"
                 ng-click="vm.createModel($event, project)"

--- a/public/components/newproject/newproject.controller.js
+++ b/public/components/newproject/newproject.controller.js
@@ -8,11 +8,11 @@
         'authService',
         'projectsService',
         'loggerService',
-        '$state', '$rootScope', '$scope', '$location'
+        '$state', '$rootScope', '$scope'
     ];
 
 
-    function NewProjectController(authService, projectsService, loggerService, $state, $rootScope, $scope, $location) {
+    function NewProjectController(authService, projectsService, loggerService, $state, $rootScope) {
 
         var vm = this;
         vm.authService = authService;
@@ -50,13 +50,12 @@
             });
         }
 
+        vm.explainimages = false;
+
         var MIN_CHOICE_LENGTH = 1;
         var MAX_CHOICE_LENGTH = 9;
         var MIN_NUM_CHOICES = 2;
         var MAX_NUM_CHOICES = 5;
-
-        $scope.showBeta = $location.search().beta;
-
 
         authService.getProfileDeferred()
             .then(function (profile) {

--- a/public/components/newproject/newproject.css
+++ b/public/components/newproject/newproject.css
@@ -42,6 +42,19 @@ md-input-container .md-input.newprojectname {
     flex-wrap: wrap;
 }
 
+.newprojectexplanation {
+    font-size: 0.85em;
+    margin: 10px;
+    text-decoration: underline;
+    color: #304ab4;
+    cursor: pointer;
+}
+
+.badge.mltinybadge {
+    font-size: 9px;
+    padding: 1.5px 5px;
+    border-radius: 8px;
+}
 
 .newprojectfield {
     border: thin grey solid;

--- a/public/components/newproject/newproject.html
+++ b/public/components/newproject/newproject.html
@@ -86,10 +86,14 @@
                            class="newprojecttype">
                     <md-option value="text" translate="WORKSHEETS.TYPES.TEXT"></md-option>
                     <md-option value="images" translate="WORKSHEETS.TYPES.IMAGES"></md-option>
+                    <md-option value="imgtfjs">{{ 'WORKSHEETS.TYPES.IMAGES' | translate }} <span class="badge">beta</span></md-option>
                     <md-option value="numbers" translate="WORKSHEETS.TYPES.NUMBERS"></md-option>
                     <md-option value="sounds" translate="WORKSHEETS.TYPES.SOUNDS"></md-option>
-                    <md-option value="imgtfjs" ng-if="showBeta">images (beta)</md-option>
                 </md-select>
+                <div class="newprojectexplanation"
+                     ng-click="vm.explainimages = !vm.explainimages"
+                     ng-if="projectType === 'images' || projectType === 'imgtfjs'"
+                     translate="NEWPROJECT.EXPLAINTYPES.NOTICE"></div>
             </md-input-container>
             <div class="well newprojecthelp"
                  ng-if="vm.focused === 'type' && projectType !== 'numbers' && !vm.creating">
@@ -99,6 +103,22 @@
                 <div translate="NEWPROJECT.TYPES.NOTES_4"></div>
                 <div translate="NEWPROJECT.TYPES.NOTES_5"></div>
             </div>
+        </div>
+        <div class="well newprojecthelp"
+             ng-if="vm.explainimages && (projectType === 'images' || projectType === 'imgtfjs')">
+            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_1"></div>
+            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_2"></div>
+            <div style="margin-top: 2em;" translate="NEWPROJECT.EXPLAINTYPES.NOTES_3"></div>
+            <div><ul style="margin-bottom: 0; padding-inline-start: 20px;">
+                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_4"></li>
+                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_5"></li>
+            </ul></div>
+            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_6"> </div>
+            <div style="margin-top: 2em;" translate="NEWPROJECT.EXPLAINTYPES.NOTES_7"> </div>
+            <div><ul style="margin-bottom: 0; padding-inline-start: 20px;">
+                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_8"></li>
+            </ul></div>
+            <div translate="NEWPROJECT.EXPLAINTYPES.NOTES_9"></div>
         </div>
 
 

--- a/public/components/projects/projects.css
+++ b/public/components/projects/projects.css
@@ -141,3 +141,7 @@
     border: thin #333 solid;
     float: right;
 }
+
+.mlprojectslist {
+    padding-bottom: 3em;
+}

--- a/public/components/projects/projects.html
+++ b/public/components/projects/projects.html
@@ -37,7 +37,7 @@
 
     <div ng-if="!vm.projects" class="loading"> </div>
 
-    <div class="text-center">
+    <div class="text-center mlprojectslist">
         <div class="mlproject" ng-repeat="project in vm.projects" id="{{project.id}}">
             <div class="mlprojectdetails placeholder" ng-if="project.isPlaceholder">
                 <div class="mlprojecttitle">{{ project.name }}</div>
@@ -50,7 +50,7 @@
                     {{ 'PROJECTS.RECOGNISING' | translate }}
                     <span class="mlprojecttype" ng-if="project.type === 'text'" translate="WORKSHEETS.TYPES.TEXT"></span>
                     <span class="mlprojecttype" ng-if="project.type === 'images'" translate="WORKSHEETS.TYPES.IMAGES"></span>
-                    <span class="mlprojecttype" ng-if="project.type === 'imgtfjs'">images (beta)</span>
+                    <span class="mlprojecttype" ng-if="project.type === 'imgtfjs'">{{ 'WORKSHEETS.TYPES.IMAGES' | translate }} <span class="badge">beta</span> </span>
                     <span class="mlprojecttype" ng-if="project.type === 'numbers'" translate="WORKSHEETS.TYPES.NUMBERS"></span>
                     <span class="mlprojecttype" ng-if="project.type === 'sounds'" translate="WORKSHEETS.TYPES.SOUNDS"></span>
                     <span ng-if="project.labelsSummary">
@@ -81,5 +81,6 @@
                     alt="Delete project" />
             </div>
         </div>
+        <br clear="all"/>
     </div>
 </div>

--- a/public/components/projects/projects.service.js
+++ b/public/components/projects/projects.service.js
@@ -45,6 +45,19 @@
                 });
         }
 
+        function changeProjectType(projectid, userid, tenant, newtype) {
+            return $http.patch('/api/classes/' + tenant + '/students/' + userid + '/projects/' + projectid, [
+                    {
+                        op : 'replace',
+                        path : '/type',
+                        value : newtype
+                    }
+                ])
+                .then(function (resp) {
+                    return resp.data;
+                });
+        }
+
         function addLabelToProject(projectid, userid, tenant, newlabel) {
             return $http.patch('/api/classes/' + tenant + '/students/' + userid + '/projects/' + projectid, [
                     {
@@ -122,6 +135,8 @@
 
             getFields : getFields,
             getLabels : getLabels,
+
+            changeProjectType : changeProjectType,
 
             addLabelToProject : addLabelToProject,
             removeLabelFromProject : removeLabelFromProject,

--- a/public/components/scratch3/scratch3.html
+++ b/public/components/scratch3/scratch3.html
@@ -87,15 +87,15 @@
             <div>
                 <img src="static/images/scratch3-recognise-label-{{ project.type }}.png">
             </div>
-            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_RECOGNISE_LABEL" translate-values='{ "type" : project.type }'></div>
+            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_RECOGNISE_LABEL" translate-values='{ "type" : project.type === "imgtfjs" ? "images" : project.type }'></div>
             <div>
                 <img src="static/images/scratch3-recognise-confidence-{{ project.type }}.png">
             </div>
-            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_RECOGNISE_CONFIDENCE" translate-values='{ "type" : project.type }'></div>
+            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_RECOGNISE_CONFIDENCE" translate-values='{ "type" : project.type === "imgtfjs" ? "images" : project.type }'></div>
             <div>
                 <img src="static/images/scratch3-label.png">
             </div>
-            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_LABELS" translate-values='{ "type" : project.type }'></div>
+            <div class="modelstatusdetail" translate="SCRATCH.EXPLAIN_LABELS"></div>
             <div class="modelstatusdetail"><strong translate="SCRATCH.SAMPLE_SCRIPT"></strong></div>
             <div>
                 <img src="static/images/scratch3-sample-{{ project.type }}.png">

--- a/public/components/training/training.html
+++ b/public/components/training/training.html
@@ -16,7 +16,6 @@
                 {{ 'PROJECTS.AS' | translate }}
                 <span class="mlprojectlabels">{{ project.labelsSummary }}</span>
             </span>
-            <span ng-if="project.type === 'imgtfjs'" class="badge">beta</span>
         </div>
     </div>
     <div style="margin: 5px;">

--- a/public/components/training/training.service.js
+++ b/public/components/training/training.service.js
@@ -112,7 +112,7 @@
             });
         }
 
-        function testModel(projectid, projecttype, userid, tenant, modelid, credsid, testdata) {
+        function testModel(projectid, userid, tenant, modelid, credsid, testdata) {
             var url = '/api/classes/' + tenant +
                         '/students/' + userid +
                         '/projects/' + projectid +
@@ -123,6 +123,27 @@
             return $http.post(url, testdata)
                 .then(function (resp) {
                     return resp.data;
+                });
+        }
+
+        function testModelPrep(projectid, userid, tenant, modelid, testdata) {
+            var url = '/api/classes/' + tenant +
+                        '/students/' + userid +
+                        '/projects/' + projectid +
+                        '/models/' + modelid +
+                        '/label';
+
+            return $http.post(url, testdata, { responseType : 'arraybuffer' })
+                .then(function (resp) {
+                    return resp.data;
+                })
+                .catch(function (err) {
+                    if (err.status) {
+                        // because we explicitly request an arraybuffer, we need
+                        //  to decode the JSON payload in the event of an error
+                        err.data = JSON.parse(new TextDecoder().decode(err.data));
+                    }
+                    throw err;
                 });
         }
 
@@ -206,6 +227,7 @@
             getModel : getModel,
             newModel : newModel,
             testModel : testModel,
+            testModelPrep : testModelPrep,
             deleteModel : deleteModel,
 
             getUnmanagedClassifiers : getUnmanagedClassifiers,

--- a/public/languages/ar.json
+++ b/public/languages/ar.json
@@ -214,6 +214,18 @@
             "NOTES_4": "لمجموعات من الأرقام أو الخيارات المتعددة ، اختر \"أرقام\"",
             "NOTES_5": "للأصوات، اختر \"الأصوات\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "اللغة ",
             "NOTES": "ما هي لغة النص في هذا المشروع؟"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "صنع",
-            "BODY": "استخدم نموذج تعلم الآلة الذي دربته لإنشاء لعبة أو تطبيق ، في Scratch أو في Python"
+            "BODY": "استخدم نموذج تعلم الآلة الذي دربته لإنشاء لعبة أو تطبيق ، في Scratch أو في Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "حذف هذا النموذج",
         "TEST_CANVAS": "ارسم شيئًا لاختبار نموذجك باستخدامه",
         "TEST_WEBCAM": "التقط صورة لاختبار نموذجك باستخدامها",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "ماذا فعلت؟",
             "PLEASEWAIT": "عادةً ما يستغرق هذا بضع دقائق ، ولكن يمكن أن يستغرق وقتًا أطول قليلاً إذا كان جهاز الكمبيوتر التدريبي مشغولاً للغاية.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "هل يوجد شيء لا يعمل؟",
             "INTRO2": "تحتوي القائمة في الأسفل على الأسئلة والمشكلات التي أسمع عنها كثيرًا. إذا رأيت شيئًا يشبه مشكلتك ، فانقر على الملخص للحصول على مزيد من المعلومات.",
             "INTRO3": "إذا كنت لا تزال عالقًا ، أو واجهت مشكلة لم أدرجها في القائمة ، عذرًا! يرجى <a href='https://groups.google.com/d/forum/mlforkids'>اطرح السؤال في مجموعة تعلم الآلة للأطفال Google </a> حتى أتمكن من المساعدة."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/cs.json
+++ b/public/languages/cs.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Pro sady čísel nebo více možností odpovědí zvol \"numbers\"",
             "NOTES_5": "Pro hlas nebo zvuky zvol \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Jazyk",
             "NOTES": "Jakým jazykem bude text v tomto projektu?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Vytvoř",
-            "BODY": "Využij naučený model k tvorbě hry nebo aplikace ve Scratchi nebo Pythonu"
+            "BODY": "Využij naučený model k tvorbě hry nebo aplikace ve Scratchi nebo Pythonu",
+            "BODY_SCRATCHONLY": "Využij naučený model k tvorbě hry nebo aplikace ve Scratchi"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Delete this model",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
             "PLEASEWAIT": "This normally takes a few minutes, but can take a little longer if the training computer is very busy.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Is something not working?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/cy.json
+++ b/public/languages/cy.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Ar gyfer setiau o rifau neu aml-ddewisiadau, dewiswch \"rhifau\"",
             "NOTES_5": "Ar gyfer lleisiau a synau, dewiswch \"synau\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Iaith",
             "NOTES": "Pa iaith fydd y testun yn y prosiect hwn?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Creu",
-            "BODY": "Defnyddiwch y model dysgu peiriant rydych chi wedi'i hyfforddi i wneud gêm neu ap, yn Scratch neu yn Python"
+            "BODY": "Defnyddiwch y model dysgu peiriant rydych chi wedi'i hyfforddi i wneud gêm neu ap, yn Scratch neu yn Python",
+            "BODY_SCRATCHONLY": "Defnyddiwch y model dysgu peiriant rydych chi wedi'i hyfforddi i wneud gêm neu ap, yn Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Dileu'r model hwn",
         "TEST_CANVAS": "Tynnwch lun rhywbeth i brofi'ch model",
         "TEST_WEBCAM": "Tynnwch lun i brofi'ch model",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Beth wyt ti wedi gwneud?",
             "PLEASEWAIT": "Mae hyn fel arfer yn cymryd ychydig funudau, ond gall gymryd ychydig mwy o amser os yw'r cyfrifiadur hyfforddi yn brysur iawn.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Onid yw rhywbeth yn gweithio?",
             "INTRO2": "Mae'r rhestr isod yn cynnwys y cwestiynau a'r materion y clywaf amdanynt amlaf. Os gwelwch rywbeth sy'n edrych yn debyg i'ch problem, cliciwch ar y crynodeb i gael mwy o wybodaeth.",
             "INTRO3": "Os ydych chi'n dal i fod yn sownd, neu os ydych chi wedi dod i broblem nad ydw i wedi'i chynnwys ar y rhestr, mae'n ddrwg gen i! <a href='https://groups.google.com/d/forum/mlforkids'>Gofynnwch gwestiwn yn y mlforkids Google Group</a> er mwyn i mi allu helpu."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/de.json
+++ b/public/languages/de.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Wähle \"Zahlen\" für Zahlen oder Multiple Choice",
             "NOTES_5": "Wähle \"Geräusche\" für Stimmen und Geräusche"
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Sprache",
             "NOTES": "In welcher Sprache wird der Text dieses Projektes sein?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Machen",
-            "BODY": "Benutze das Machine-Learning-Modell, das du trainiert hast, um ein Spiel oder eine App in Scratch, Python oder dem App Inventor zu erstellen"
+            "BODY": "Benutze das Machine-Learning-Modell, das du trainiert hast, um ein Spiel oder eine App in Scratch, Python oder dem App Inventor zu erstellen",
+            "BODY_SCRATCHONLY": "Benutze das Machine-Learning-Modell, das du trainiert hast, um ein Spiel oder eine App in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Lösche dieses Modell",
         "TEST_CANVAS": "Zeichne etwas, um dein Modell zu testen",
         "TEST_WEBCAM": "Mache eine Foto, um dein Modell zu testen",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Was hast du bisher gemacht?",
             "PLEASEWAIT": "Gedulde dich ein paar Minuten. Wenn der Trainingscomputer viel zu tun hat, kann es etwas länger dauern.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Funktioniert etwas nicht?",
             "INTRO2": "Die folgende Liste enthält häufige Fragen. Wenn du etwas findest, das deinem Problem ähnelt, klicke auf die Zusammenfassung für mehr Infos.",
             "INTRO3": "Wenn du trotzdem nicht weiterkommst, oder ein Problem hast, das hier nicht aufgelistet ist, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/el.json
+++ b/public/languages/el.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Για σύνολα αριθμών ή πολλαπλές επιλογές, επίλεξε \"αριθμοί\"",
             "NOTES_5": "Για φωνές και ήχους, επίλεξε \"ήχοι\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Γλώσσα",
             "NOTES": "Σε ποια γλώσσα θα είναι το κείμενο για αυτό το έργο;"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Υλοποίηση",
-            "BODY": "Χρησιμοποίησε το μοντέλο μηχανικής μάθησης που έχεις εκπαιδεύσει για να δημιουργήσεις ένα παιχνίδι ή μια εφαρμογή, στο Scratch ή στην Python"
+            "BODY": "Χρησιμοποίησε το μοντέλο μηχανικής μάθησης που έχεις εκπαιδεύσει για να δημιουργήσεις ένα παιχνίδι ή μια εφαρμογή, στο Scratch ή στην Python",
+            "BODY_SCRATCHONLY": "Χρησιμοποίησε το μοντέλο μηχανικής μάθησης που έχεις εκπαιδεύσει για να δημιουργήσεις ένα παιχνίδι ή μια εφαρμογή, στο Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Διαγραφή αυτού του μοντέλου",
         "TEST_CANVAS": "Σχεδίασε κάτι για να δοκιμάσεις το μοντέλο σου",
         "TEST_WEBCAM": "Πάρε μια φωτογραφία για να δοκιμάσεις το μοντέλο σου",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Τι έχεις κάνει;",
             "PLEASEWAIT": "Αυτό συνήθως διαρκεί μερικά λεπτά, αλλά μπορεί να κρατήσει λίγο περισσότερο εάν ο υπολογιστής είναι πολύ απασχολημένος.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Μήπως κάτι δε λειτουργεί;",
             "INTRO2": "Η παρακάτω λίστα περιέχει ερωτήσεις και θέματα που ακούω συχνότερα. Αν δεις κάτι που μοιάζει με το πρόβλημά σου, κάνε κλικ στην περίληψη για περισσότερες πληροφορίες.",
             "INTRO3": "Αν εξακολουθείς να έχεις κολλήσει ή αντιμετωπίζεις κάποιο πρόβλημα που δεν συμπεριλαμβάνεται στη λίστα, ζητώ συγγνώμη! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -214,6 +214,18 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Language",
             "NOTES": "What language will the text in this project be?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch, Python, or App Inventor",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Delete this model",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
             "PLEASEWAIT": "This normally takes a few minutes, but can take a little longer if the training computer is very busy.",
@@ -1641,6 +1658,32 @@
             "INTRO1": "Is something not working?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/es.json
+++ b/public/languages/es.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Para conjuntos de números u opciones múltiples, elija \"números\"",
             "NOTES_5": "Para voces y sonidos, choose \"sonidos\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Idioma",
             "NOTES": "¿En qué idioma será el texto de este proyecto?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Crea",
-            "BODY": "Usa el modelo de aprendizaje automático que has entrenado para crear un juego o una aplicación, en Scratch o en Python"
+            "BODY": "Usa el modelo de aprendizaje automático que has entrenado para crear un juego o una aplicación, en Scratch o en Python",
+            "BODY_SCRATCHONLY": "Usa el modelo de aprendizaje automático que has entrenado para crear un juego o una aplicación, en Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Borra este modelo ",
         "TEST_CANVAS": "Dibuja algo para probar tu modelo",
         "TEST_WEBCAM": "Haz una foto par probar tu modelo",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "¿Qué has hecho hasta ahora?",
             "PLEASEWAIT": "Normalmente, tarda unos minutos, pero puede ser un poco más si la computadora está muy ocupada.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "¿Algo no funciona? ",
             "INTRO2": "En la siguiente lista puedes encontrar las preguntas y problemas más frecuentes. Si ninguna resuelve tu problema, haz click sobre el resumen para obtener más información. ",
             "INTRO3": "Si sigues atascado o tu problema no está en la lista, por favor, <a href='https://groups.google.com/d/forum/mlforkids'> envía un correo a </a> or <a href='https://github.com/IBM/taxinomitis/issues'>y reporta el error</a> para que pueda ayudarte."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/fr.json
+++ b/public/languages/fr.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Pour les ensembles de nombres ou les choix multiples, sélectionnez \"numbers\"",
             "NOTES_5": "Pour la voix et les sons, sélectionnez \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Langue",
             "NOTES": "En quelle langue le texte de ce projet sera-t-il rédigé ?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Faire",
-            "BODY": "Utilisez le modèle d'apprentissage machine que vous avez formé pour créer un jeu ou une application, en Scratch ou en Python."
+            "BODY": "Utilisez le modèle d'apprentissage machine que vous avez formé pour créer un jeu ou une application, en Scratch ou en Python.",
+            "BODY_SCRATCHONLY": "Utilisez le modèle d'apprentissage machine que vous avez formé pour créer un jeu ou une application, en Scratch."
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Supprimer ce modèle",
         "TEST_CANVAS": "Dessinez quelque chose pour tester votre modèle",
         "TEST_WEBCAM": "Prenez une photo pour tester votre modèle",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Qu'avez vous accompli ?",
             "PLEASEWAIT": "Cela prend normalement quelques minutes, mais cela peut prendre un peu plus de temps si l'ordinateur d'entraînement est très occupé.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Quelque chose ne fonctionne pas ?",
             "INTRO2": "La liste ci-dessous contient les questions et les problèmes dont j'entends parler le plus souvent. Si vous voyez quelque chose qui ressemble à votre problème, cliquez sur le résumé pour plus d'informations.",
             "INTRO3": "Si vous êtes toujours coincé, ou si vous avez rencontré un problème que je n'ai pas inclus dans la liste, désolé ! Veuillez <a href='https://groups.google.com/d/forum/mlforkids'>m'envoyer un courriel</a> ou <a href='https://github.com/IBM/taxinomitis/issues'>créer un rapport de problème </a> pour que je puisse aider."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/hr.json
+++ b/public/languages/hr.json
@@ -214,6 +214,18 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Language",
             "NOTES": "What language will the text in this project be?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Delete this model",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
             "PLEASEWAIT": "This normally takes a few minutes, but can take a little longer if the training computer is very busy.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Is something not working?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/it.json
+++ b/public/languages/it.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Per set di numeri o scelte multiple, scegli \"numeri\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Lingua",
             "NOTES": "In che lingua sarà il testo di questo progetto?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Programma",
-            "BODY": "Utilizza il modello di machine learning che hai addestrato per realizzare un gioco o un'app, in Scratch o in Python"
+            "BODY": "Utilizza il modello di machine learning che hai addestrato per realizzare un gioco o un'app, in Scratch o in Python",
+            "BODY_SCRATCHONLY": "Utilizza il modello di machine learning che hai addestrato per realizzare un gioco o un'app, in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Cancella questo modello",
         "TEST_CANVAS": "Disegna qualcosa con cui testare il tuo modello",
         "TEST_WEBCAM": "Scatta una foto con cui testare il tuo modello",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Cos'hai fatto?",
             "PLEASEWAIT": "Questo richiede in genere alcuni minuti, ma può richiedere più tempo se il training computer è molto occupato.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Qualcosa non funziona?",
             "INTRO2": "L'elenco che segue contiene le domande e i problemi che sento di più spesso. Se vedi qualcosa che assomiglia al tuo problema, clicca sul sommario per maggiori informazioni.",
             "INTRO3": "Se sei ancora bloccato o hai riscontrato un problema che non ho incluso nell'elenco, scusa! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/ja.json
+++ b/public/languages/ja.json
@@ -214,6 +214,18 @@
             "NOTES_4": "数字のあつまりや、複数選択肢は、\"数値\"を選択してください。",
             "NOTES_5": "音声は、\"音声\"を選択してください。"
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "使用言語",
             "NOTES": "このプロジェクトでは何語を利用しますか?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "プログラム作成",
-            "BODY": "あなたがトレーニングした機械学習モデルを用いて、ScratchやPythonでゲームやアプリを作成する。"
+            "BODY": "あなたがトレーニングした機械学習モデルを用いて、ScratchやPythonでゲームやアプリを作成する。",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "このモデルを削除",
         "TEST_CANVAS": "あなたのモデルをテストするために何か描いてください",
         "TEST_WEBCAM": "あなたのモデルをテストするために写真を撮ってください",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "何をしましたか?",
             "PLEASEWAIT": "通常２，３分かかりますが、コンピューターが忙しい時には、それより長くかかることがあります。",
@@ -1640,6 +1657,32 @@
             "INTRO1": "何か上手く動作しないですか？",
             "INTRO2": "よくある問題や質問を以下のリストにまとめています。もし、類似の問題に直面したら、まとめの文章をクリックして詳細を参照ください。",
             "INTRO3": "それでも問題が解決できない場合や、リストにない問題に遭遇した場合は、お手数でも <a href='https://groups.google.com/d/forum/mlforkids'>私に</a>英語でメールをするか、<a href='https://github.com/IBM/taxinomitis/issues'>このリンクから問題を報告</a>して頂ければ、問題解決を支援します。"
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/ko.json
+++ b/public/languages/ko.json
@@ -214,6 +214,18 @@
             "NOTES_4": "숫자 등을 인식하도록 원한다면 \"숫자(numbers)\"를 선택하세요",
             "NOTES_5": "다양한 소리나 목소리를 인식하도록 원한다면 \"사운드(sounds)\"를 "
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "언어",
             "NOTES": "이 프로젝트에서 어떤 언어를 인식하도록 할까요?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "만들기",
-            "BODY": "스크래치나 파이썬을 사용하여 여러분이 만든 머신러닝 모델로 게임이나 프로그램을 만들어보세요."
+            "BODY": "스크래치나 파이썬을 사용하여 여러분이 만든 머신러닝 모델로 게임이나 프로그램을 만들어보세요.",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "스크래치 2",
@@ -374,6 +387,10 @@
         "DELETE": "모델 삭제",
         "TEST_CANVAS": "무엇인가를 그려서 모델을 테스트해보세요.",
         "TEST_WEBCAM": "사진을 찍어서 모델을 ",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "무엇을 하고 있나요?",
             "PLEASEWAIT": "몇 분이 걸려요. 하지만 트레이닝 컴퓨터가 바쁘다면 조금 더 걸릴 수 있어요.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "뭔가 작동하지 않나요?",
             "INTRO2": "아래 목록에는 가장 자주 듣는 질문과 문제가 포함되어 있습니다. 문제와 비슷한 것으로 보이는 것이 있으면 요약 정보를 클릭하세요.",
             "INTRO3": "아직 해결이 안되거나, 목록에 포함되지 않은 문제가 발생하였나요? 죄송합니다! <a href='https://groups.google.com/d/forum/mlforkids'>로 이메일을 보내주세요. </a> 또는 <a href='https://github.com/IBM/taxinomitis/issues'> 문제 보고서</a>를 작성해주세요."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/nl-be.json
+++ b/public/languages/nl-be.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Voor groepen van cijfers of meerkeuzes, kies \"getal\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Taal",
             "NOTES": "In welke taal zal de tekst van dit project zijn?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Maak",
-            "BODY": "Gebruik het machine learning model dat je hebt getraind om een spel of applicatie te maken, in Scratch of Python"
+            "BODY": "Gebruik het machine learning model dat je hebt getraind om een spel of applicatie te maken, in Scratch of Python",
+            "BODY_SCRATCHONLY": "Gebruik het machine learning model dat je hebt getraind om een spel of applicatie te maken, in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Verwijder dit model",
         "TEST_CANVAS": "Teken iets om je model mee te testen",
         "TEST_WEBCAM": "Maak een foto om je model mee te testen",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Wat heb je gedaan?",
             "PLEASEWAIT": "Dit duurt normaal ongeveer een paar minuten, maar het kan iets langer duren als de training computer druk bezig is.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Werkt er iets niet?",
             "INTRO2": "De lijst hieronder bevat de vragen en problemen die ik het meest hoorde. Als je iets ziet dat lijkt op je probleem, klik dan op de samenvatting voor meer info.",
             "INTRO3": "Als je nog steeds vast zit of je hebt een probleem dat niet voorkomt in de lijst, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/pl.json
+++ b/public/languages/pl.json
@@ -214,6 +214,18 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Language",
             "NOTES": "What language will the text in this project be?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Delete this model",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
             "PLEASEWAIT": "This normally takes a few minutes, but can take a little longer if the training computer is very busy.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Is something not working?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/pt-br.json
+++ b/public/languages/pt-br.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Para conjunto de números ou múltipla escolha, escolha \"números\"",
             "NOTES_5": "Para vozes e sons, escolha choose \"sons\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Língua",
             "NOTES": "Em qual idioma será o texto deste projeto?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Faça",
-            "BODY": "Use o modelo de aprendizado de máquina que você treinou para fazer um jogo ou aplicativo, em Scratch ou em Python"
+            "BODY": "Use o modelo de aprendizado de máquina que você treinou para fazer um jogo ou aplicativo, em Scratch ou em Python",
+            "BODY_SCRATCHONLY": "Use o modelo de aprendizado de máquina que você treinou para fazer um jogo ou aplicativo, em Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Deletar este modelo",
         "TEST_CANVAS": "Desenhe algo para testar o seu modelo",
         "TEST_WEBCAM": "Tire uma foto para testar o seu modelo",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "O que você fez?",
             "PLEASEWAIT": "Isso normalmente leva alguns minutos, mas pode demorar um pouco mais se o computador de treinamento estiver muito ocupado.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Alguma coisa não está funcionando?",
             "INTRO2": "A lista abaixo contém as perguntas e problemas que eu ouço mais frequentemente. Se você ver algo parecido com o seu problema, clique no resumo para mais informações.",
             "INTRO3": "Se você ainda está preso ou se deparou com um problema que não incluí na lista, desculpe! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/ru.json
+++ b/public/languages/ru.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Для набора чисел или множественного выбора выберите «числа»",
             "NOTES_5": "Для голосов и звуков выберите «звуки»"
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Язык",
             "NOTES": "На каком языке будет текст в этом проекте?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Создать",
-            "BODY": "Используйте модель машинного обучения, которую вы обучили, для создания игры или приложения, на Scratch или на Python"
+            "BODY": "Используйте модель машинного обучения, которую вы обучили, для создания игры или приложения, на Scratch или на Python",
+            "BODY_SCRATCHONLY": "Используйте модель машинного обучения, которую вы обучили, для создания игры или приложения, на Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Удалить эту модель",
         "TEST_CANVAS": "Нарисуйте что-нибудь для тестирования своей модели",
         "TEST_WEBCAM": "Сделайте фото, чтобы протестировать модель",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Что Вы сделали?",
             "PLEASEWAIT": "Обычно это занимает несколько минут, но может занять немного больше времени, если компьютер очень загружен.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Что-то не работает?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/si-lk.json
+++ b/public/languages/si-lk.json
@@ -214,6 +214,18 @@
             "NOTES_4": "ඉලක්කම් වල එකතූන් හෝ බහුවරණ සදහා \"numbers\" තෝරන්න",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "භාෂාව",
             "NOTES": "ඔබේ ව්‍යාපෘතියේ text තිබෙන්නේ කුමන භාෂාවෙන්ද?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "හදන්න",
-            "BODY": "Scratch හෝ පයිතන් වල, app එකක් හෝ game එකක් හදන්න ඔබ පුහුණු කළ machine learning ආක්‍රුතිය භාවිත කරන්න"
+            "BODY": "Scratch හෝ පයිතන් වල, app එකක් හෝ game එකක් හදන්න ඔබ පුහුණු කළ machine learning ආක්‍රුතිය භාවිත කරන්න",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "මොඩලය මකා දමන්න",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "ඔබ කුමක්ද කළේ?",
             "PLEASEWAIT": "සාමාන්‍යයෙන් මෙයට මිනිත්තු කීපයක් ගතවේ, නමුත් පුහුණු පරිගණකය ඉතා කාර්යය බහුලනම් කාලය මදක් වැඩිවිය හැක.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Is something not working?",
             "INTRO2": "The list below contains the questions and issues that I hear about most often. If you see something that looks similar to your problem, click on the summary for more info.",
             "INTRO3": "If you're still stuck, or you've run into a problem I've not included in the list, sorry! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/sv-se.json
+++ b/public/languages/sv-se.json
@@ -214,6 +214,18 @@
             "NOTES_4": "Välj \"siffror\" för uppsättningar med siffror eller lista med val",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Language",
             "NOTES": "What language will the text in this project be?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Radera denna modell",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Vad har du gjort?",
             "PLEASEWAIT": "Det här tar normalt ett par minuter, men kan ta lite längre tid om träningsdatorn är väldigt upptagen.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Är det nåt som inte funkar?",
             "INTRO2": "Listan nedan innehåller de frågor och problem som jag oftast får. Om du ser något som liknar problemet du har, klicka på sammanfattningen för mer information.",
             "INTRO3": "Om du fortfarande sitter fast, eller om du stöter på ett problem som jag inte har tagit med i listan, ber jag om ursäkt för det! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/tr.json
+++ b/public/languages/tr.json
@@ -214,6 +214,18 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "Language",
             "NOTES": "What language will the text in this project be?"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "Bu modeli sil",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "Neler yaptınız?",
             "PLEASEWAIT": "Bu genellikle birkaç dakika sürer, ancak eğitim bilgisayarı çok meşgulse biraz daha uzun sürebilir.",
@@ -1640,6 +1657,32 @@
             "INTRO1": "Yolunda gitmeyen bir şeyler mi var?",
             "INTRO2": "Aşağıdaki listede en çok duyduğum sorular ve sorunlar yer alıyor. Sizin yaşadığınıza benzer bir sorun görürseniz ayrıntılı bilgi için özeti tıklatın.",
             "INTRO3": "Hala zor durumdaysanız veya listeye eklemediğim bir sorunla karşı karşıyaysanız, üzgünüm! Please <a href='https://groups.google.com/d/forum/mlforkids'>ask a question in the mlforkids Google Group</a> so that I can help."
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/zh-cn.json
+++ b/public/languages/zh-cn.json
@@ -214,6 +214,18 @@
             "NOTES_4": "对于数字组或多个选项,请选择\"数字\" ",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "语言",
             "NOTES": "这个项目中的文字是什么语言？"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "Make",
-            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python"
+            "BODY": "Use the machine learning model you've trained to make a game or app, in Scratch or in Python",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": " Scratch ",
@@ -374,6 +387,10 @@
         "DELETE": "删除此模型",
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "你做了什么？",
             "PLEASEWAIT": "这通常需要几分钟,但如果训练计算机非常繁忙,可能需要更长的时间。",
@@ -1640,6 +1657,32 @@
             "INTRO1": "有什么不行吗？",
             "INTRO2": "下面的列表包含我经常听到的问题和问题。如果您看到与您的问题类似的内容,请点击摘要以获取更多信息。",
             "INTRO3": "如果你仍然卡住了,或者你遇到了问题,我还没有列入名单,对不起！请<a href='https://groups.google.com/d/forum/mlforkids'>给我发电子邮件</a>或<a href='https://github.com/IBM/taxinomitis/issues'>创建问题报告</a>,以便我可以提供帮助。"
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/public/languages/zh-tw.json
+++ b/public/languages/zh-tw.json
@@ -214,6 +214,18 @@
             "NOTES_4": "一系列的數字或多個選項，請選擇「數字」",
             "NOTES_5": "聲音與音樂，請選擇「聲音」"
         },
+        "EXPLAINTYPES": {
+            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
+            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
+            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
+            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
+            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
+            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
+            "NOTES_9": "But, it can only be used for Scratch projects."
+        },
         "LANGUAGE": {
             "LABEL": "語言",
             "NOTES": "這個專案中的文字是什麼語言呢？"
@@ -320,7 +332,8 @@
         },
         "MAKES": {
             "TITLE": "成果應用",
-            "BODY": "在Scratch或Python中使用你訓練好的機器學習模型來製作遊戲或應用程式"
+            "BODY": "在Scratch或Python中使用你訓練好的機器學習模型來製作遊戲或應用程式",
+            "BODY_SCRATCHONLY": "Use the machine learning model you've trained to make a game or app in Scratch"
         },
         "SCRATCH": {
             "TITLE": "Scratch",
@@ -374,6 +387,10 @@
         "DELETE": "刪除這個模型",
         "TEST_CANVAS": "畫一些東西來測試你的模型",
         "TEST_WEBCAM": "照一張相來訓練你的模型",
+        "CHANGETYPE": {
+            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
+            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+        },
         "WHATHAVEYOUDONE": {
             "TITLE": "你完成了什麼？",
             "PLEASEWAIT": "這通常需要花費幾分鐘的時間。但如果伺服器忙碌中會需要花更長的時間",
@@ -1641,6 +1658,32 @@
             "INTRO1": "發生錯誤了嗎？",
             "INTRO2": "以下清單包含我們最常聽見的問題。如果你看到與你問題相似的內容，請點擊摘要文字來取得更多資訊",
             "INTRO3": "如果你仍然發生錯誤，或是遇到了我沒有包含在清單中的問題，很抱歉造成你的不便！請<a href='https://groups.google.com/d/forum/mlforkids'>洽詢兒童機器學習群組</a>讓我們可以提供協助"
+        },
+
+        "PROJECTS": {
+            "TITLE": "Project questions",
+
+            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
+            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
+            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
+            "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of trainiing examples.",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
+            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
+            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
+            "Q1-A-12": "Models do not need to be automatically deleted.",
+            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
+            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+
+            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
+            "Q2-A-2": "The link to do this is in top-right of the page.",
+            "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",
+            "Q2-A-4": "The Scratch blocks for image projects work differently for the two different modes, so if you have a Scratch window open when you do this, you will need to refresh the page so that the Scratch extension can be updated."
         },
 
         "SCRATCH": {

--- a/sql/postgresql.sql
+++ b/sql/postgresql.sql
@@ -147,7 +147,7 @@ CREATE TABLE mlforkidsdb.taxinoclassifiers (
 
 CREATE TABLE mlforkidsdb.tenants (
     id character varying(36) NOT NULL PRIMARY KEY,
-    projecttypes character varying(26) DEFAULT 'text,numbers,sounds'::character varying NOT NULL,
+    projecttypes character varying(34) DEFAULT 'text,numbers,sounds,imgtfjs'::character varying NOT NULL,
     maxusers smallint DEFAULT '8'::smallint NOT NULL,
     maxprojectsperuser smallint DEFAULT '3'::smallint NOT NULL,
     textclassifiersexpiry smallint DEFAULT '2'::smallint NOT NULL,

--- a/src/lib/db/objects.ts
+++ b/src/lib/db/objects.ts
@@ -16,6 +16,13 @@ import * as ObjectStoreTypes from '../objectstore/types';
 //
 // -----------------------------------------------------------------------------
 
+export function getProjectTypeId(type: string) {
+    if (projects.typeLabels.includes(type)) {
+        return projects.typesByLabel[type].id;
+    }
+    throw new Error('Invalid project type ' + type);
+}
+
 export function createProject(
     userid: string, classid: string,
     type: string,
@@ -82,7 +89,7 @@ export function createProject(
         id : projectid,
         userid,
         classid,
-        typeid : projects.typesByLabel[type].id,
+        typeid : getProjectTypeId(type),
         name,
         labels : '',
         language,
@@ -1075,7 +1082,7 @@ export function getClassDbRow(tenant: Objects.ClassTenant): Objects.ClassDbRow {
 export function getDefaultClassTenant(classid: string): Objects.ClassTenant {
     return {
         id : classid,
-        supportedProjectTypes : [ 'text', 'images', 'numbers', 'sounds' ],
+        supportedProjectTypes : [ 'text', 'images', 'numbers', 'sounds', 'imgtfjs' ],
         tenantType : Objects.ClassTenantType.UnManaged,
         maxUsers : 30,
         maxProjectsPerUser : 3,

--- a/src/lib/db/store.ts
+++ b/src/lib/db/store.ts
@@ -177,6 +177,45 @@ export async function updateProjectCrowdSourced(
 }
 
 
+export async function updateProjectType(
+    userid: string, classid: string, projectid: string,
+    oldtype: Objects.ProjectTypeLabel, newtype: Objects.ProjectTypeLabel,
+): Promise<void>
+{
+    const queryName = 'dbqn-update-projects-type';
+    const queryString = 'UPDATE projects ' +
+                        'SET typeid = $1 ' +
+                        'WHERE userid = $2 AND classid = $3 AND id = $4 AND typeid = $5';
+    const queryValues = [
+        dbobjects.getProjectTypeId(newtype),
+        userid, classid, projectid,
+        dbobjects.getProjectTypeId(oldtype),
+    ];
+
+    const response = await dbExecute(queryName, queryString, queryValues);
+    if (response.rowCount === 1) {
+        // success
+        return;
+    }
+
+    /* istanbul ignore else */
+    if (response.rowCount === 0) {
+        log.warn({ userid, classid, projectid, func : 'updateProjectType' },
+                 'Project not found');
+        throw new Error('Project not found');
+    }
+    else {
+        // id is a primary key, so an update can only affect 0 or 1 rows
+        log.error({
+            func : 'updateProjectType',
+            userid, classid, projectid,
+            response,
+        }, 'Unexpected response');
+        throw new Error('Unexpected response when updating project status');
+    }
+}
+
+
 export async function getNumberProjectFields(
     userid: string, classid: string, projectid: string,
 ): Promise<Objects.NumbersProjectField[]>
@@ -2755,6 +2794,20 @@ export async function getLatestSiteAlert(): Promise<Objects.SiteAlert | undefine
 // UBER DELETERS
 //
 // -----------------------------------------------------------------------------
+
+
+export async function deleteWatsonClassifiers(projectid: string, classid: string): Promise<void> {
+    try {
+        const classifiers = await getImageClassifiers(projectid);
+        const tenant = await getClassTenant(classid);
+        for (const classifier of classifiers) {
+            await visualrec.deleteClassifier(tenant, classifier);
+        }
+    }
+    catch (err) {
+        log.error({ err, projectid, classid }, 'Failed to clean up Vis Rec classifiers');
+    }
+}
 
 
 export async function deleteEntireProject(userid: string, classid: string, project: Objects.Project): Promise<void> {

--- a/src/lib/restapi/index.ts
+++ b/src/lib/restapi/index.ts
@@ -40,7 +40,7 @@ export default function setup(app: Express.Application): void {
     app.use(query());
     app.use(helmet({
         contentSecurityPolicy: {
-            // TODO : remove this after trying it out in prod for a few days
+            // TODO : https://github.com/IBM/taxinomitis/issues/346 will remove this
             reportOnly : true,
             directives: serverConfig.CSP_DIRECTIVES,
         },

--- a/src/lib/restapi/models.ts
+++ b/src/lib/restapi/models.ts
@@ -367,6 +367,21 @@ async function testModel(req: Express.Request, res: Express.Response) {
             const classes = await numbers.testClassifier(userid, classid, requestTimestamp, projectid, numberdata);
             return res.json(classes);
         }
+        else if (type === 'imgtfjs') {
+            // this behaves slightly differently - the API endpoint returns data
+            //  ready for testing, rather than the results from testing
+            const imageurl = req.body.image;
+
+            if (!imageurl) {
+                return errors.missingData(res);
+            }
+
+            const downloadSpec = await visualrec.getImageDownloadSpec('placeholder', imageurl);
+            const imageData = await download.resizeUrl(downloadSpec.url,
+                                                       visualrec.IMAGE_WIDTH_PIXELS,
+                                                       visualrec.IMAGE_HEIGHT_PIXELS);
+            return res.send(imageData);
+        }
         else if (type === 'sounds') {
             return errors.notImplemented(res);
         }
@@ -388,6 +403,14 @@ async function testModel(req: Express.Request, res: Express.Response) {
             err.statusCode === 400)
         {
             return res.status(httpstatus.BAD_REQUEST).send({ error : err.message });
+        }
+        if (err.message && err.message.startsWith(download.ERRORS.DOWNLOAD_FAIL)) {
+            return res.status(httpstatus.BAD_REQUEST)
+                    .send({ error : 'The test image could not be downloaded' });
+        }
+        if (err.message === download.ERRORS.DOWNLOAD_FILETYPE_UNSUPPORTED) {
+            return res.status(httpstatus.BAD_REQUEST)
+                    .send({ error : 'The test image is a type that cannot be used' });
         }
 
         log.error({ err, body : req.body }, 'Test error');

--- a/src/lib/restapi/projects.ts
+++ b/src/lib/restapi/projects.ts
@@ -242,9 +242,11 @@ async function deleteProject(req: auth.RequestWithProject, res: Express.Response
 
 
 
+type ExpectedProjectPatches = 'labels' | 'isCrowdSourced' | 'type';
 
 
-function getProjectPatch(req: Express.Request, expected: 'labels' | 'isCrowdSourced') {
+
+function getProjectPatch(req: Express.Request, expected: ExpectedProjectPatches[]) {
     const patchRequests = req.body;
 
     if (Array.isArray(patchRequests) === false) {
@@ -267,7 +269,9 @@ function getProjectPatch(req: Express.Request, expected: 'labels' | 'isCrowdSour
     }
     let value = patchRequest.value;
 
-    if (patchRequest.path === '/labels' && expected === 'labels') {
+    const path: string = patchRequest.path;
+
+    if (path === '/labels' && expected.includes('labels')) {
         if (op === 'add' || op === 'remove') {
             if (typeof value !== 'string') {
                 throw new Error('PATCH requests to add or remove a label should specify a string');
@@ -297,18 +301,28 @@ function getProjectPatch(req: Express.Request, expected: 'labels' | 'isCrowdSour
             throw new Error('Invalid PATCH op');
         }
 
-        return { op, value };
+        return { op, value, path };
     }
-    else if (patchRequest.path === '/isCrowdSourced' && expected === 'isCrowdSourced') {
+    else if (path === '/type' && expected.includes('type')) {
+        if (op === 'replace' && typeof value === 'string' &&
+            (value === 'images' || value === 'imgtfjs'))
+        {
+            return { op, value, path };
+        }
+        else {
+            throw new Error('Invalid PATCH op');
+        }
+    }
+    else if (path === '/isCrowdSourced' && expected.includes('isCrowdSourced')) {
         if (op === 'replace' && typeof value === 'boolean') {
-            return { op, value };
+            return { op, value, path };
         }
         else {
             throw new Error('Invalid PATCH op');
         }
     }
     else {
-        throw new Error('Only modifications to project ' + expected + ' are supported');
+        throw new Error('Only modifications to project ' + expected.join(' or ') + ' are supported');
     }
 }
 
@@ -328,7 +342,7 @@ async function modifyProject(req: Express.Request, res: Express.Response) {
 
     let patch;
     try {
-        patch = getProjectPatch(req, 'labels');
+        patch = getProjectPatch(req, ['labels', 'type']);
     }
     catch (err) {
         return res.status(httpstatus.BAD_REQUEST)
@@ -340,21 +354,37 @@ async function modifyProject(req: Express.Request, res: Express.Response) {
     try {
         let response: string[];
 
-        switch (patch.op) {
-        case 'add':
-            response = await store.addLabelToProject(userid, classid, projectid, patch.value);
-            break;
-        case 'remove':
-            // delete anything with the label from the S3 Object Store
-            await deleteImages(classid, userid, projectid, patch.value);
-            // delete anything with the label from the DB
-            response = await store.removeLabelFromProject(userid, classid, projectid, patch.value);
-            break;
-        case 'replace':
-            response = await store.replaceLabelsForProject(userid, classid, projectid, patch.value);
-            break;
-        default:
+        if (patch.path === '/labels') {
+            switch (patch.op) {
+            case 'add':
+                response = await store.addLabelToProject(userid, classid, projectid, patch.value);
+                break;
+            case 'remove':
+                // delete anything with the label from the S3 Object Store
+                await deleteImages(classid, userid, projectid, patch.value);
+                // delete anything with the label from the DB
+                response = await store.removeLabelFromProject(userid, classid, projectid, patch.value);
+                break;
+            case 'replace':
+                response = await store.replaceLabelsForProject(userid, classid, projectid, patch.value);
+                break;
+            default:
+                response = [];
+            }
+        }
+        else if (patch.path === '/type') {
+            // the only valid change of project type is between images and imgtfjs, as they
+            //  both store training data in the same place and in the same way
+            const oldtype = patch.value === 'images' ? 'imgtfjs' : 'images';
+            if (oldtype === 'images') {
+                await store.deleteWatsonClassifiers(projectid, classid);
+            }
+
+            await store.updateProjectType(userid, classid, projectid, oldtype, patch.value);
             response = [];
+        }
+        else {
+            return errors.missingData(res);
         }
 
         res.json(response);
@@ -379,7 +409,7 @@ async function shareProject(req: auth.RequestWithProject, res: Express.Response)
 
         let patch;
         try {
-            patch = getProjectPatch(req, 'isCrowdSourced');
+            patch = getProjectPatch(req, ['isCrowdSourced']);
         }
         catch (err) {
             return res.status(httpstatus.BAD_REQUEST)

--- a/src/lib/utils/download.ts
+++ b/src/lib/utils/download.ts
@@ -225,6 +225,9 @@ export function resizeUrl(url: string, width: number, height: number): Promise<B
                                 .on('error', reject)
                                 .toBuffer((err, buff) => {
                                     if (err) {
+                                        if (err.message === 'Input buffer contains unsupported image format') {
+                                            return reject(new Error(ERRORS.DOWNLOAD_FILETYPE_UNSUPPORTED));
+                                        }
                                         return reject(err);
                                     }
                                     return resolve(buff);

--- a/src/tests/db/objects.ts
+++ b/src/tests/db/objects.ts
@@ -1280,7 +1280,7 @@ describe('DB objects', () => {
             const created = dbobjects.createClassTenant('testing');
             assert.deepStrictEqual(created, {
                 id : 'testing',
-                projecttypes : 'text,images,numbers,sounds',
+                projecttypes : 'text,images,numbers,sounds,imgtfjs',
                 ismanaged : 0,
                 maxusers : 30,
                 maxprojectsperuser : 3,

--- a/src/tests/db/tenantstore.ts
+++ b/src/tests/db/tenantstore.ts
@@ -59,7 +59,7 @@ describe('DB store - tenants', () => {
         const newclass: Types.ClassTenant = await store.modifyClassTenantExpiries(id, 100, 40);
         assert.deepStrictEqual(newclass, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -78,7 +78,7 @@ describe('DB store - tenants', () => {
         const newclass: Types.ClassTenant = await store.modifyClassTenantExpiries(id, 6, 7);
         assert.deepStrictEqual(newclass, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -89,7 +89,7 @@ describe('DB store - tenants', () => {
         let fetched: Types.ClassTenant = await store.getClassTenant(id);
         assert.deepStrictEqual(fetched, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -100,7 +100,7 @@ describe('DB store - tenants', () => {
         const updated: Types.ClassTenant = await store.modifyClassTenantExpiries(id, 12, 14);
         assert.deepStrictEqual(updated, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -111,7 +111,7 @@ describe('DB store - tenants', () => {
         fetched = await store.getClassTenant(id);
         assert.deepStrictEqual(fetched, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -124,7 +124,7 @@ describe('DB store - tenants', () => {
         fetched = await store.getClassTenant(id);
         assert.deepStrictEqual(fetched, {
             id,
-            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds'],
+            supportedProjectTypes : ['text', 'images', 'numbers', 'sounds', 'imgtfjs'],
             tenantType : Types.ClassTenantType.UnManaged,
             maxUsers : 30,
             maxProjectsPerUser : 3,
@@ -151,7 +151,7 @@ describe('DB store - tenants', () => {
             imageClassifierExpiry : 24,
             maxUsers : 124,
             tenantType : Types.ClassTenantType.Managed,
-            supportedProjectTypes : [ 'text', 'images', 'numbers', 'sounds' ],
+            supportedProjectTypes : [ 'text', 'images', 'numbers', 'sounds', 'imgtfjs' ],
         });
         return store.deleteClassTenant(id);
     });

--- a/src/tests/restapi/users.ts
+++ b/src/tests/restapi/users.ts
@@ -77,7 +77,7 @@ describe('REST API - users', () => {
                         maxTextModels : 0,
                         maxImageModels : 0,
                         maxUsers: 30,
-                        supportedProjectTypes: [ 'text', 'images', 'numbers', 'sounds' ],
+                        supportedProjectTypes: [ 'text', 'images', 'numbers', 'sounds', 'imgtfjs' ],
                         tenantType : Types.ClassTenantType.UnManaged,
                         isManaged : false,
                         maxProjectsPerUser: 3,


### PR DESCRIPTION
This adds the final missing feature to enable parity between
WVR and TFJS training which is to test an image classifier by
providing a URL. To avoid CORS issues, retrieving the image
data is deferred to the server, which can then be tested in the
browser.

With this final feature, and a week's successful testing of the
private beta, I'm now making this widely available. Image
projects can now be trained in locally in the browser by all
classes.

I'm not removing Watson Visual Recognition at this point, as
a) the TensorFlow.js support hasn't been tested widely enough yet
b) TensorFlow support doesn't work for App Inventor or Python yet

This commit enables the feature, as well as allowing students
to switch between the two project types, with some additional
documentation to explain the difference between in-browser and
Watson Visual Recognition training.

Closes: #351

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>