### PR TITLE
Docker-compose setup for ML4Kids

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM postgres
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get install -y nodejs
+
+RUN psql -c "CREATE USER ml4kdbuser WITH PASSWORD 'ml4kdbpwd' LOGIN;"
+RUN psql -c "CREATE DATABASE mlforkidsdb OWNER ml4kdbuser;"
+RUN psql -U ml4kdbuser -f sql/postgresql.sql -d mlforkidsdb
+
+ENV POSTGRESQLHOST=localhost
+ENV POSTGRESQLPORT=5432
+ENV POSTGRESQLUSER=ml4kdbuser
+ENV POSTGRESQLPASSWORD=ml4kdbpwd
+ENV POSTGRESQLDATABASE=mlforkidsdb
+
+ENV PORT=3000
+ENV HOST=0.0.0.0
+
+EXPOSE 3000
+
+RUN npm install
+RUN npm run build_notest
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-FROM postgres
+FROM node:12-buster-slim
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN psql -c "CREATE USER ml4kdbuser WITH PASSWORD 'ml4kdbpwd' LOGIN;"
-RUN psql -c "CREATE DATABASE mlforkidsdb OWNER ml4kdbuser;"
-RUN psql -U ml4kdbuser -f sql/postgresql.sql -d mlforkidsdb
 
-ENV POSTGRESQLHOST=localhost
-ENV POSTGRESQLPORT=5432
-ENV POSTGRESQLUSER=ml4kdbuser
-ENV POSTGRESQLPASSWORD=ml4kdbpwd
-ENV POSTGRESQLDATABASE=mlforkidsdb
+#ENV POSTGRESQLHOST=127.0.0.1
+#ENV POSTGRESQLPORT=5432
+#ENV POSTGRESQLUSER=ml4kdbuser
+#ENV POSTGRESQLPASSWORD=ml4kdbpwd
+#ENV POSTGRESQLDATABASE=mlforkidsdb
 
-ENV PORT=3000
-ENV HOST=0.0.0.0
+#ENV PORT=3000
+#ENV HOST=0.0.0.0
 
 EXPOSE 3000
+
+COPY ./ /tmp/ml4k/
+
+WORKDIR /tmp/ml4k
 
 RUN npm install
 RUN npm run build_notest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,17 +14,17 @@ services:
         POSTGRES_HOST: ml4knet
         POSTGRES_PORT: 5432
       networks:
-      - ml4knet
+        - ml4knet
     ml4k:
       build: .
       environment:
-        POSTGRESQLHOST: ml4knet
+        POSTGRESQLHOST: postgres
         POSTGRESQLPORT: 5432
         POSTGRESQLUSER: ml4kdbuser
         POSTGRESQLPASSWORD: ml4kdbpwd
         POSTGRESQLDATABASE: mlforkidsdb
         PORT: 3000
-        HOST: localhost
+        HOST: 0.0.0.0
       ports:
         - "8875:3000"
       networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+
+version: "3"
+services:
+    postgres:
+      image: postgres
+      ports:
+        - "5432:5432"
+      volumes:
+        - ./sql/postgresql.sql:/docker-entrypoint-initdb.d/init.sql
+      environment:
+        POSTGRES_PASSWORD: ml4kdbpwd
+        POSTGRES_DB: mlforkidsdb
+        POSTGRES_USER: ml4kdbuser
+        POSTGRES_HOST: ml4knet
+        POSTGRES_PORT: 5432
+      networks:
+      - ml4knet
+    ml4k:
+      build: .
+      environment:
+        POSTGRESQLHOST: ml4knet
+        POSTGRESQLPORT: 5432
+        POSTGRESQLUSER: ml4kdbuser
+        POSTGRESQLPASSWORD: ml4kdbpwd
+        POSTGRESQLDATABASE: mlforkidsdb
+        PORT: 3000
+        HOST: localhost
+      ports:
+        - "8875:3000"
+      networks:
+        - ml4knet
+      depends_on:
+        - postgres
+
+networks:
+  ml4knet:


### PR DESCRIPTION
I had a go at a docker-compose setup to build and run a containerised version of ML4Kids:

- postgres container
- node container that builds ML4Kids.

Possible next steps:

- clean the ML4Kids container of build artefacts;
- try a docker `buildx` crossbuild Github Action to try to build versions for RPi ([crib example](https://github.com/OpenComputingLab/vce-jupyter-stacks/blob/main/.github/workflows/buildx-base.yml))