### PR TITLE
feat: Promote imgtfjs projects out of beta

### DIFF
--- a/public/components/help/help.html
+++ b/public/components/help/help.html
@@ -49,18 +49,15 @@
                     <p translate="HELP.PROJECTS.Q1-A-4"></p>
                     <p><ul>
                         <li translate="HELP.PROJECTS.Q1-A-5"></li>
-                        <li translate="HELP.PROJECTS.Q1-A-6"></li>
                         <li translate="HELP.PROJECTS.Q1-A-7"></li>
                     </ul></p>
                     <p translate="HELP.PROJECTS.Q1-A-8"></p>
                     <p translate="HELP.PROJECTS.Q1-A-9"></p>
                     <p><ul>
                         <li translate="HELP.PROJECTS.Q1-A-10"></li>
-                        <li translate="HELP.PROJECTS.Q1-A-11"></li>
                         <li translate="HELP.PROJECTS.Q1-A-12"></li>
                     </ul></p>
                     <p translate="HELP.PROJECTS.Q1-A-13"></p>
-                    <p translate="HELP.PROJECTS.Q1-A-14"></p>
                 </div>
             </div>
         </div>

--- a/public/components/newproject/newproject.css
+++ b/public/components/newproject/newproject.css
@@ -2,8 +2,16 @@
     font-size: 2.5em;
 }
 
+.newprojectpage {
+    padding: 2em;
+}
+
 md-input-container .md-input.newprojectname {
     height: 1.5em;
+}
+
+.newprojectname.newcrowdsourced {
+    font-size: 1.7em;
 }
 
 .newprojectrow {
@@ -20,6 +28,10 @@ md-input-container .md-input.newprojectname {
     color: #666699;
     vertical-align: middle;
     margin-right: 5px;
+}
+
+.newprojecthelp .helpfirstline {
+    margin-bottom: 1em;
 }
 
 .newprojecttype {

--- a/public/components/newproject/newproject.html
+++ b/public/components/newproject/newproject.html
@@ -9,7 +9,7 @@
         <button class="btn btn-primary" ng-click="vm.authService.login()" translate="APP.LOGIN"></button>
     </div>
 </div>
-<div ng-if="isAuthenticated" style="padding: 2em">
+<div ng-if="isAuthenticated" class="newprojectpage">
     <div ng-repeat="error in vm.errors" class="alert alert-danger alert-dismissible pageheadermsg" role="alert" ng-click="vm.dismissAlert('errors', $index)">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong translate="APP.ERROR"></strong> {{ error.message }}<br/>
@@ -32,13 +32,12 @@
                 <md-checkbox
                        ng-model="crowdSourced"
                        ng-focus="vm.focused = 'crowdsourced'"
-                       ng-disabled="vm.creating"
-                       class="newprojectname"
-                       style="font-size: 1.7em">
+                       ng-disabled="creating"
+                       class="newprojectname newcrowdsourced">
                        {{ 'NEWPROJECT.WHOLE_CLASS_PROJECT.TITLE' | translate }}
                 </md-checkbox>
             </md-input-container>
-            <div class="well newprojecthelp" ng-if="vm.focused === 'crowdsourced' && !vm.creating">
+            <div class="well newprojecthelp" ng-if="vm.focused === 'crowdsourced' && !creating">
                 <div style="margin-bottom: 1em" translate="NEWPROJECT.WHOLE_CLASS_PROJECT.NOTES_1"></div>
                 <div translate="NEWPROJECT.WHOLE_CLASS_PROJECT.NOTES_2"></div>
             </div>
@@ -57,7 +56,7 @@
                        ng-required="true"
                        name="projectName"
                        ng-model="projectName"
-                       ng-disabled="vm.creating"
+                       ng-disabled="creating"
                        ng-focus="vm.focused = 'name'"
                        class="newprojectname"/>
                 <div ng-messages="newProject.projectName.$error" ng-show="newProject.projectName.$dirty">
@@ -66,7 +65,7 @@
                 </div>
             </md-input-container>
             <div class="well newprojecthelp"
-                 ng-if="vm.focused === 'name' && !vm.creating"
+                 ng-if="vm.focused === 'name' && !creating"
                  translate="NEWPROJECT.PROJECT_NAME.NOTES"></div>
         </div>
 
@@ -81,45 +80,52 @@
                 <label translate="NEWPROJECT.TYPES.LABEL"></label>
                 <md-select ng-required="true"
                            ng-model="projectType"
-                           ng-disabled="vm.creating"
+                           ng-disabled="creating"
                            ng-focus="vm.focused = 'type'"
                            class="newprojecttype">
                     <md-option value="text" translate="WORKSHEETS.TYPES.TEXT"></md-option>
-                    <md-option value="images" translate="WORKSHEETS.TYPES.IMAGES" ng-hide="vm.profile && vm.profile.tenant === 'session-users'"></md-option>
-                    <md-option value="imgtfjs">{{ 'WORKSHEETS.TYPES.IMAGES' | translate }} <span class="badge">beta</span></md-option>
+                    <md-option value="IMAGES" translate="WORKSHEETS.TYPES.IMAGES"></md-option>
                     <md-option value="numbers" translate="WORKSHEETS.TYPES.NUMBERS"></md-option>
                     <md-option value="sounds" translate="WORKSHEETS.TYPES.SOUNDS"></md-option>
                 </md-select>
                 <div class="newprojectexplanation"
-                     ng-click="vm.explainimages = !vm.explainimages"
                      ng-if="projectType === 'images' || projectType === 'imgtfjs'"
                      ng-hide="vm.profile && vm.profile.tenant === 'session-users'"
                      translate="NEWPROJECT.EXPLAINTYPES.NOTICE"></div>
             </md-input-container>
             <div class="well newprojecthelp"
-                 ng-if="vm.focused === 'type' && projectType !== 'numbers' && !vm.creating">
-                <div style="margin-bottom: 1em" translate="NEWPROJECT.TYPES.NOTES_1"></div>
+                 ng-if="vm.focused === 'type' && projectType !== 'numbers' && !creating">
+                <div class="helpfirstline" translate="NEWPROJECT.TYPES.NOTES_1"></div>
                 <div translate="NEWPROJECT.TYPES.NOTES_2"></div>
                 <div translate="NEWPROJECT.TYPES.NOTES_3"></div>
                 <div translate="NEWPROJECT.TYPES.NOTES_4"></div>
                 <div translate="NEWPROJECT.TYPES.NOTES_5"></div>
             </div>
         </div>
-        <div class="well newprojecthelp"
-             ng-if="vm.explainimages && (projectType === 'images' || projectType === 'imgtfjs')">
-            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_1"></div>
-            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_2"></div>
-            <div style="margin-top: 2em;" translate="NEWPROJECT.EXPLAINTYPES.NOTES_3"></div>
-            <div><ul style="margin-bottom: 0; padding-inline-start: 20px;">
-                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_4"></li>
-                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_5"></li>
-            </ul></div>
-            <div style="margin-bottom: 1em" translate="NEWPROJECT.EXPLAINTYPES.NOTES_6"> </div>
-            <div style="margin-top: 2em;" translate="NEWPROJECT.EXPLAINTYPES.NOTES_7"> </div>
-            <div><ul style="margin-bottom: 0; padding-inline-start: 20px;">
-                <li translate="NEWPROJECT.EXPLAINTYPES.NOTES_8"></li>
-            </ul></div>
-            <div translate="NEWPROJECT.EXPLAINTYPES.NOTES_9"></div>
+
+
+        <!-- ---------------------------------------- -->
+        <!--   MODEL LOCATION                         -->
+        <!--                                          -->
+        <!-- displayed only for image projects        -->
+        <!-- ---------------------------------------- -->
+        <div class="newprojectfields newprojectlanguage" ng-show="projectType === 'IMAGES' && canChooseImageModelType">
+            <md-input-container class="newprojectform">
+                <label translate="NEWPROJECT.IMAGEPROJECTS.LABEL"></label>
+                <md-select ng-model="imagesmodeltype"
+                           ng-focus="vm.focused = 'imageprojects'"
+                           ng-disabled="creating"
+                           class="newprojecttype">
+                    <md-option value="imgtfjs" ng-selected="supportsLocalImageProjects" translate="NEWPROJECT.IMAGEPROJECTS.TYPES.IMGTFJS"></md-option>
+                    <md-option value="images" ng-selected="!supportsLocalImageProjects" translate="NEWPROJECT.IMAGEPROJECTS.TYPES.IMAGES"></md-option>
+                </md-select>
+            </md-input-container>
+            <div class="well newprojecthelp"
+                    ng-if="vm.focused === 'imageprojects' && projectType === 'IMAGES' && !creating">
+                <div translate="NEWPROJECT.IMAGEPROJECTS.NOTES_1" class="helpfirstline"></div>
+                <div translate="NEWPROJECT.IMAGEPROJECTS.NOTES_2" class="helpfirstline"></div>
+                <div translate="NEWPROJECT.IMAGEPROJECTS.NOTES_3"></div>
+            </div>
         </div>
 
 
@@ -133,7 +139,7 @@
                 <label translate="NEWPROJECT.LANGUAGE.LABEL"></label>
                 <md-select ng-model="language"
                            ng-focus="vm.focused = 'language'"
-                           ng-disabled="vm.creating"
+                           ng-disabled="creating"
                            class="newprojecttype">
                     <md-option value="en" ng-selected="true">English</md-option>
                     <md-option value="ar">Arabic</md-option>
@@ -151,7 +157,7 @@
                 </md-select>
             </md-input-container>
             <div class="well newprojecthelp"
-                    ng-if="vm.focused === 'language' && projectType === 'text' && !vm.creating"
+                    ng-if="vm.focused === 'language' && projectType === 'text' && !creating"
                     translate="NEWPROJECT.LANGUAGE.NOTES"></div>
         </div>
 
@@ -175,7 +181,7 @@
                            name="numfield_{{$index}}"
                            ng-required="true"
                            ng-model="field.name"
-                           ng-disabled="vm.creating"
+                           ng-disabled="creating"
                            ng-focus="vm.focused = 'fieldname' + $index"
                            class="newprojectfieldname"/>
                     <div ng-messages="newProject['numfield_' + $index].$error" ng-show="newProject['numfield_' + $index].$dirty">
@@ -191,7 +197,7 @@
                     <label translate="NEWPROJECT.FIELDS.TYPE.TITLE"></label>
                     <md-select ng-required="true"
                                ng-model="field.type"
-                               ng-disabled="vm.creating"
+                               ng-disabled="creating"
                                ng-focus="vm.focused = 'fieldtype' + $index"
                                class="newprojectfieldtype">
                         <md-option value="number" translate="NEWPROJECT.FIELDS.TYPE.NUMBER"></md-option>
@@ -285,8 +291,8 @@
             <span flex></span>
             <md-button
                 class="md-raised md-primary"
-                ng-disabled="vm.creating || newProject.$invalid || vm.isInvalid(projectType)"
-                ng-click="vm.confirm({ name : projectName, type : projectType, fields : vm.fields, language : language, isCrowdSourced : (isTeacher && crowdSourced) ? true : false })"
+                ng-disabled="creating || newProject.$invalid || isInvalid(projectType)"
+                ng-click="vm.confirm({ name : projectName, type : getProjectType(projectType, imagesmodeltype), fields : vm.fields, language : language, isCrowdSourced : (isTeacher && crowdSourced) ? true : false })"
                 translate="NEWPROJECT.CREATE">
             </md-button>
             <md-button ui-sref="projects" translate="APP.CANCEL"></md-button>

--- a/public/components/projects/projects.html
+++ b/public/components/projects/projects.html
@@ -49,8 +49,7 @@
                 <div class="mlprojectdescription">
                     {{ 'PROJECTS.RECOGNISING' | translate }}
                     <span class="mlprojecttype" ng-if="project.type === 'text'" translate="WORKSHEETS.TYPES.TEXT"></span>
-                    <span class="mlprojecttype" ng-if="project.type === 'images'" translate="WORKSHEETS.TYPES.IMAGES"></span>
-                    <span class="mlprojecttype" ng-if="project.type === 'imgtfjs'">{{ 'WORKSHEETS.TYPES.IMAGES' | translate }} <span class="badge">beta</span> </span>
+                    <span class="mlprojecttype" ng-if="project.type === 'images' || project.type === 'images'" translate="WORKSHEETS.TYPES.IMAGES"></span>
                     <span class="mlprojecttype" ng-if="project.type === 'numbers'" translate="WORKSHEETS.TYPES.NUMBERS"></span>
                     <span class="mlprojecttype" ng-if="project.type === 'sounds'" translate="WORKSHEETS.TYPES.SOUNDS"></span>
                     <span ng-if="project.labelsSummary">

--- a/public/components/teacher_apikeys/teacher_apikeys.controller.js
+++ b/public/components/teacher_apikeys/teacher_apikeys.controller.js
@@ -20,6 +20,8 @@
             UNLIMITED : -2
         };
 
+        vm.hideVisualRecognition = false;
+
         var alertId = 1;
         vm.errors = [];
         vm.warnings = [];
@@ -126,6 +128,9 @@
 
                             if (vm.policy.isManaged === false) {
                                 getAllCredentials(profile);
+                            }
+                            if (vm.policy.supportedProjectTypes.indexOf('images') === -1) {
+                                vm.hideVisualRecognition = true;
                             }
                         })
                         .catch(function (err) {

--- a/public/components/teacher_apikeys/teacher_apikeys.html
+++ b/public/components/teacher_apikeys/teacher_apikeys.html
@@ -109,57 +109,60 @@
 
 
         <div ng-if="vm.credentials.loading.visrec === false" style="border-top: thin #444 solid; padding-top: 1em; margin-bottom: 2em;">
-            <div translate="TEACHER.APIKEYS.INTRO_VISUALRECOGNITION"></div>
-            <div ng-if="vm.credentials.failed.visrec" class="credserror" translate="TEACHER.APIKEYS.ERROR_FETCHING_VISUALRECOG"></div>
-            <div class="newlabelbuttons">
-                <div class="newlabelbutton" ng-click="vm.addCredentials($event, 'visrec')" style="margin-right: 1.5em">
-                    <div class="newlabelicon">+</div>
-                    <div class="newlabellabel" translate="TEACHER.APIKEYS.ADDAPIKEY"></div>
+            <div ng-if="vm.hideVisualRecognition" translate="TEACHER.APIKEYS.INTRO_IMAGES"></div>
+            <div ng-hide="vm.hideVisualRecognition" style="padding: 0; margin: 0">
+                <div translate="TEACHER.APIKEYS.INTRO_VISUALRECOGNITION"></div>
+                <div ng-if="vm.credentials.failed.visrec" class="credserror" translate="TEACHER.APIKEYS.ERROR_FETCHING_VISUALRECOG"></div>
+                <div class="newlabelbuttons">
+                    <div class="newlabelbutton" ng-click="vm.addCredentials($event, 'visrec')" style="margin-right: 1.5em">
+                        <div class="newlabelicon">+</div>
+                        <div class="newlabellabel" translate="TEACHER.APIKEYS.ADDAPIKEY"></div>
+                    </div>
                 </div>
-            </div>
-            <table ng-if="vm.credentials.conv && vm.credentials.visrec.length > 0" class="studentslist" style="margin-bottom: 1em; min-width: 95%">
-                <tr ng-repeat="creds in vm.credentials.visrec" ng-class-even="'even'" ng-class-odd="'odd'">
-                    <td class="additionalDialogInfo" style="width: 60px;">
-                        <img width=50 height=50 src="static/images/visualrecognition.jpg" alt="Watson Visual Recognition">
-                    </td>
-                    <td class="studentslistdetail" ng-class="{ 'placeholder' : creds.isPlaceholder }">
-                        <div class="listheading" translate="TEACHER.APIKEYS.APIKEY"></div>
-                        <div class="listmain">
-                            {{ creds.apikey }}
-                        </div>
-                    </td>
-                    <td class="studentslistdetail" style="cursor: pointer" ng-click="vm.modifyCredentials($event, creds, 'visrec')" ng-hide="creds.isPlaceholder">
-                        <div class="listheading" translate="TEACHER.APIKEYS.NUMBER_OF_ML_MODELS"></div>
-                        <div class="listmain" ng-switch="creds.credstype">
-                            <span style="font-size: 1.2em;" ng-switch-when="visrec_lite">2</span>
-                            <span class="glyphicon glyphicon-alert apikeywarning" ng-if="creds.credstype === 'visrec_lite'">
-                                <md-tooltip style="font-size: 1.2em;">{{ 'TEACHER.APIKEYS.LITE_30_DAYS_EXPIRE' | translate }}</md-tooltip>
-                            </span>
-                            <span style="font-size: 1.2em;" ng-switch-when="visrec_standard" translate="TEACHER.APIKEYS.UNLIMITED"></span>
-                            <span style="font-size: 1.4em; font-style: italic" ng-switch-default translate="TEACHER.APIKEYS.UNKNOWN"></span>
-                        </div>
-                    </td>
-                    <td class="studentslistactions" ng-hide="creds.isPlaceholder">
-                        <button class="btn btn-default" ng-click="vm.verifyCredentials($event, creds)" ng-disabled="creds.verifying || creds.verified">
-                            <md-progress-circular ng-if="creds.verifying" style="display: inline" class="md-hue-2" md-diameter="12px"></md-progress-circular>
-                            <span class="verifybutton" ng-hide="creds.verified" translate="TEACHER.APIKEYS.VERIFY">Verify</span>
-                            <span class="glyphicon glyphicon-ok" ng-if="creds.verified"></span>
-                        </button>
-                        <button class="btn btn-default" ng-click="vm.deleteCredentials($event, creds, 'visrec')" translate="TEACHER.APIKEYS.REMOVE"></button>
-                    </td>
-                </tr>
-            </table>
-            <div style="font-size: 1.25em; text-align: right; margin-right: 1em; cursor: pointer;"
-                 ng-if="vm.credentials.visrec && vm.credentials.visrec.length > 0"
-                 ng-click="vm.explainLimit()">
-                {{ 'TEACHER.APIKEYS.LIMIT_IMAGE_PROJECTS' | translate }}
-                <span style="font-size: 1.15em; font-style: italic" ng-if="vm.credentials.totals.visrec === vm.CONSTANTS.UNKNOWN" translate="TEACHER.APIKEYS.UNKNOWN"></span>
-                <span style="font-size: 1.15em;" ng-if="vm.credentials.totals.visrec === vm.CONSTANTS.UNLIMITED" translate="TEACHER.APIKEYS.UNLIMITED"></span>
-                <span style="font-size: 1.15em; font-weight: bold;" ng-if="vm.credentials.totals.visrec >= 0">{{ vm.credentials.totals.visrec }}</span>
-            </div>
-            <div class="credserror" ng-if="vm.credentials.visrec && vm.credentials.visrec.length === 0">
-                <div translate="TEACHER.APIKEYS.NO_IMAGE_CREDENTIALS"></div>
-                <div class="errormsg" translate="TEACHER.APIKEYS.LINK_TO_APIKEYS_GUIDE"></div>
+                <table ng-if="vm.credentials.conv && vm.credentials.visrec.length > 0" class="studentslist" style="margin-bottom: 1em; min-width: 95%">
+                    <tr ng-repeat="creds in vm.credentials.visrec" ng-class-even="'even'" ng-class-odd="'odd'">
+                        <td class="additionalDialogInfo" style="width: 60px;">
+                            <img width=50 height=50 src="static/images/visualrecognition.jpg" alt="Watson Visual Recognition">
+                        </td>
+                        <td class="studentslistdetail" ng-class="{ 'placeholder' : creds.isPlaceholder }">
+                            <div class="listheading" translate="TEACHER.APIKEYS.APIKEY"></div>
+                            <div class="listmain">
+                                {{ creds.apikey }}
+                            </div>
+                        </td>
+                        <td class="studentslistdetail" style="cursor: pointer" ng-click="vm.modifyCredentials($event, creds, 'visrec')" ng-hide="creds.isPlaceholder">
+                            <div class="listheading" translate="TEACHER.APIKEYS.NUMBER_OF_ML_MODELS"></div>
+                            <div class="listmain" ng-switch="creds.credstype">
+                                <span style="font-size: 1.2em;" ng-switch-when="visrec_lite">2</span>
+                                <span class="glyphicon glyphicon-alert apikeywarning" ng-if="creds.credstype === 'visrec_lite'">
+                                    <md-tooltip style="font-size: 1.2em;">{{ 'TEACHER.APIKEYS.LITE_30_DAYS_EXPIRE' | translate }}</md-tooltip>
+                                </span>
+                                <span style="font-size: 1.2em;" ng-switch-when="visrec_standard" translate="TEACHER.APIKEYS.UNLIMITED"></span>
+                                <span style="font-size: 1.4em; font-style: italic" ng-switch-default translate="TEACHER.APIKEYS.UNKNOWN"></span>
+                            </div>
+                        </td>
+                        <td class="studentslistactions" ng-hide="creds.isPlaceholder">
+                            <button class="btn btn-default" ng-click="vm.verifyCredentials($event, creds)" ng-disabled="creds.verifying || creds.verified">
+                                <md-progress-circular ng-if="creds.verifying" style="display: inline" class="md-hue-2" md-diameter="12px"></md-progress-circular>
+                                <span class="verifybutton" ng-hide="creds.verified" translate="TEACHER.APIKEYS.VERIFY">Verify</span>
+                                <span class="glyphicon glyphicon-ok" ng-if="creds.verified"></span>
+                            </button>
+                            <button class="btn btn-default" ng-click="vm.deleteCredentials($event, creds, 'visrec')" translate="TEACHER.APIKEYS.REMOVE"></button>
+                        </td>
+                    </tr>
+                </table>
+                <div style="font-size: 1.25em; text-align: right; margin-right: 1em; cursor: pointer;"
+                    ng-if="vm.credentials.visrec && vm.credentials.visrec.length > 0"
+                    ng-click="vm.explainLimit()">
+                    {{ 'TEACHER.APIKEYS.LIMIT_IMAGE_PROJECTS' | translate }}
+                    <span style="font-size: 1.15em; font-style: italic" ng-if="vm.credentials.totals.visrec === vm.CONSTANTS.UNKNOWN" translate="TEACHER.APIKEYS.UNKNOWN"></span>
+                    <span style="font-size: 1.15em;" ng-if="vm.credentials.totals.visrec === vm.CONSTANTS.UNLIMITED" translate="TEACHER.APIKEYS.UNLIMITED"></span>
+                    <span style="font-size: 1.15em; font-weight: bold;" ng-if="vm.credentials.totals.visrec >= 0">{{ vm.credentials.totals.visrec }}</span>
+                </div>
+                <div class="credserror" ng-if="vm.credentials.visrec && vm.credentials.visrec.length === 0">
+                    <div translate="TEACHER.APIKEYS.NO_IMAGE_CREDENTIALS"></div>
+                    <div class="errormsg" translate="TEACHER.APIKEYS.LINK_TO_APIKEYS_GUIDE"></div>
+                </div>
             </div>
         </div>
 

--- a/public/languages/ar.json
+++ b/public/languages/ar.json
@@ -212,17 +212,15 @@
             "NOTES_4": "لمجموعات من الأرقام أو الخيارات المتعددة ، اختر \"أرقام\"",
             "NOTES_5": "للأصوات، اختر \"الأصوات\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "اللغة ",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "ارسم شيئًا لاختبار نموذجك باستخدامه",
         "TEST_WEBCAM": "التقط صورة لاختبار نموذجك باستخدامها",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "ماذا فعلت؟",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": " نماذج تعلم الآلة التدريبية لمشاريع<span class='mlprojecttype'> الصور</span> تستخدم<a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": " نماذج تعلم الآلة التدريبية لمشاريع <span class='mlprojecttype'>الأرقام</span> <strong>لا </strong>تتطلب أي مفاتيح واجهة برمجة التطبيقات API",
             "INTRO_SOUNDS": " نماذج تعلم الآلة التدريبية لمشاريع <span class='mlprojecttype'>الأصوات</span> <strong>لا </strong>تتطلب أي مفاتيح واجهة برمجة التطبيقات API",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "تعذّر الحصول على كلمات مرور Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "تعذّر الحصول على مفاتيح واجهة برمجة التطبيقات API الخاصة بالتعرف المرئي",
             "USERNAME": "اسم المستخدم",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/cs.json
+++ b/public/languages/cs.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Pro sady čísel nebo více možností odpovědí zvol \"numbers\"",
             "NOTES_5": "Pro hlas nebo zvuky zvol \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Jazyk",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API Keys used by your class are being managed for you.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/cy.json
+++ b/public/languages/cy.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Ar gyfer setiau o rifau neu aml-ddewisiadau, dewiswch \"rhifau\"",
             "NOTES_5": "Ar gyfer lleisiau a synau, dewiswch \"synau\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Iaith",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Tynnwch lun rhywbeth i brofi'ch model",
         "TEST_WEBCAM": "Tynnwch lun i brofi'ch model",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Beth wyt ti wedi gwneud?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "Mae hyfforddi modelau dysgu peiriant ar gyfer prosiectau <span class='mlprojecttype'>delweddau</span> yn defnyddio <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "<strong>Nid</strong> oes angen allweddi API ar gyfer hyfforddi modelau dysgu peiriant ar gyfer prosiectau <span class='mlprojecttype'>rhifau</span>",
             "INTRO_SOUNDS": "<strong>Nid</strong> oes angen allweddi API ar gyfer hyfforddi modelau dysgu peiriant ar gyfer prosiectau <span class='mlprojecttype'>sain</span> ",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Wedi methu cael eich cyfrineiriau Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "Wedi methu cael eich bysellau API Visual Recognition",
             "USERNAME": "Enw defnyddiwr",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/de.json
+++ b/public/languages/de.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Wähle \"Zahlen\" für Zahlen oder Multiple Choice",
             "NOTES_5": "Wähle \"Geräusche\" für Stimmen und Geräusche"
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Sprache",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Zeichne etwas, um dein Modell zu testen",
         "TEST_WEBCAM": "Mache eine Foto, um dein Modell zu testen",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Was hast du bisher gemacht?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "Zum Trainieren der Machine Learning Models für <span class='mlprojecttype'>Bilderkennung</span> wird <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a> genutzt",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Dein Watson Assistant Passwort ist fehlgeschlagen",
             "ERROR_FETCHING_VISUALRECOG": "Deine Visual Recognition API Schlüssel sind fehlgeschlagen",
             "USERNAME": "Benutzername",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/el.json
+++ b/public/languages/el.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Για σύνολα αριθμών ή πολλαπλές επιλογές, επίλεξε \"αριθμοί\"",
             "NOTES_5": "Για φωνές και ήχους, επίλεξε \"ήχοι\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Γλώσσα",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Σχεδίασε κάτι για να δοκιμάσεις το μοντέλο σου",
         "TEST_WEBCAM": "Πάρε μια φωτογραφία για να δοκιμάσεις το μοντέλο σου",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Τι έχεις κάνει;",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "Η εκπαίδευση μοντέλων μηχανικής μάθησης για <span class='mlprojecttype'>έργα εικόνων</span> χρησιμοποιεί την <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Η εκπαίδευση μοντέλων μηχανικής μάθησης για έργα <span class='mlprojecttype'>αριθμών</span> <strong>δεν</strong> απαιτεί κλειδιά API",
             "INTRO_SOUNDS": "Η εκπαίδευση μοντέλων μηχανικής μάθησης για έργα <span class='mlprojecttype'>ήχου</span> δεν απαιτεί κανένα κλειδί API",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Απέτυχε η λήψη των κωδικών πρόσβασής σου στο Watson Assistant ",
             "ERROR_FETCHING_VISUALRECOG": "Απέτυχε η λήψη κλειδιών API για Οπτική Αναγνώριση",
             "USERNAME": "Όνομα χρήστη",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -218,17 +218,15 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Language",
@@ -392,8 +390,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
@@ -1531,9 +1529,10 @@
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
 
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
 
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
@@ -1705,23 +1704,20 @@
         "PROJECTS": {
             "TITLE": "Project questions",
 
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
 
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/es.json
+++ b/public/languages/es.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Para conjuntos de números u opciones múltiples, elija \"números\"",
             "NOTES_5": "Para voces y sonidos, choose \"sonidos\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Idioma",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Dibuja algo para probar tu modelo",
         "TEST_WEBCAM": "Haz una foto par probar tu modelo",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "¿Qué has hecho hasta ahora?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "El entrenamiento de modelos de aprendizaje automático para proyectos de <span class='mlprojecttype'>imagen</span> usa <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Error al obtener tus claves de Watson Assistant ",
             "ERROR_FETCHING_VISUALRECOG": "Error al obtener tus claves de Visual Recognition API ",
             "USERNAME": "Usuario",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/fr.json
+++ b/public/languages/fr.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Pour les ensembles de nombres ou les choix multiples, sélectionnez \"numbers\"",
             "NOTES_5": "Pour la voix et les sons, sélectionnez \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Langue",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Dessinez quelque chose pour tester votre modèle",
         "TEST_WEBCAM": "Prenez une photo pour tester votre modèle",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Qu'avez vous accompli ?",
@@ -1484,6 +1482,7 @@
             "INTRO_VISUALRECOGNITION": "Modèles d'entraînement pour l'apprentissage machine pour des projets avec des <span class='mlprojecttype'>images</span> utilisant <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "L'entraînement des modèles d'apprentissage machine pour les projets de type <span class='mlprojecttype'>numbers</span><strong> ne nécessite aucune clé API</strong>. ",
             "INTRO_SOUNDS": "L'entraînement des modèles d'apprentissage machine pour les projets de type <span class='mlprojecttype'>sound</span> <strong>ne nécessite aucune clé API </strong>.",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Échec de l'obtention de vos mots de passe Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "Échec de l'obtention de vos clés API Visual Recognition",
             "USERNAME": "Nom d'utilisateur",
@@ -1628,22 +1627,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/hr.json
+++ b/public/languages/hr.json
@@ -212,17 +212,15 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Language",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API Keys used by your class are being managed for you.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/it.json
+++ b/public/languages/it.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Per set di numeri o scelte multiple, scegli \"numeri\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Lingua",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Disegna qualcosa con cui testare il tuo modello",
         "TEST_WEBCAM": "Scatta una foto con cui testare il tuo modello",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Cos'hai fatto?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "L'addestramento dei modelli di machine learning per progetti di <span class='mlprojecttype'>immagini</span> utilizza <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Impossibile ottenere le password del Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "Impossibile ottenere le tue Visual Recognition API keys",
             "USERNAME": "Nome utente",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/ja.json
+++ b/public/languages/ja.json
@@ -212,17 +212,15 @@
             "NOTES_4": "数字のあつまりや、複数選択肢は、\"数値\"を選択してください。",
             "NOTES_5": "音声は、\"音声\"を選択してください。"
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "使用言語",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "あなたのモデルをテストするために何か描いてください",
         "TEST_WEBCAM": "あなたのモデルをテストするために写真を撮ってください",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "何をしましたか?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "機械学習モデルを <span class='mlprojecttype'>画像</span>プロジェクトのためにトレーニングする際には、<a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>を利用します。",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "あなたの Watson Assistant パスワードを取得するのに失敗しました。",
             "ERROR_FETCHING_VISUALRECOG": "あなたの Visual Recognition API キーを取得するのに失敗しました。",
             "USERNAME": "ユーザ名",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/ko.json
+++ b/public/languages/ko.json
@@ -212,17 +212,15 @@
             "NOTES_4": "숫자 등을 인식하도록 원한다면 \"숫자(numbers)\"를 선택하세요",
             "NOTES_5": "다양한 소리나 목소리를 인식하도록 원한다면 \"사운드(sounds)\"를 "
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "언어",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "무엇인가를 그려서 모델을 테스트해보세요.",
         "TEST_WEBCAM": "사진을 찍어서 모델을 ",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "무엇을 하고 있나요?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "<span class='mlprojecttype'>images</span> 프로젝트를 <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>를 사용하여 만들어보세요",
             "INTRO_NUMBERS": "<span class='mlprojecttype'>숫자</span> 프로젝트를 만들기 위해서는 API keys가 필요하지 <strong>않습니다.</strong>",
             "INTRO_SOUNDS": "<span class='mlprojecttype'></span> 프로젝트를 만들기 위해서는 API keys가 필요하지 <strong>않습니다.</strong>",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "여러분의 Watson Assistant 비밀번호가 잘못되었습니다.",
             "ERROR_FETCHING_VISUALRECOG": "여러분의 Visual Recognition API keys가 잘못되었습니다.",
             "USERNAME": "사용자명",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/nl-be.json
+++ b/public/languages/nl-be.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Voor groepen van cijfers of meerkeuzes, kies \"getal\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Taal",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Teken iets om je model mee te testen",
         "TEST_WEBCAM": "Maak een foto om je model mee te testen",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Wat heb je gedaan?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "Het trainen van machine learning modellen voor <span class='mlprojecttype'>afbeeldingsherkenning</span> projecten gebeurt via de <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Het ophalen van je Watson Assistant paswoord is niet gelukt",
             "ERROR_FETCHING_VISUALRECOG": "Het ophalen van je Visual Recognition API keys is niet gelukt",
             "USERNAME": "Gebruikersnaam",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/pl.json
+++ b/public/languages/pl.json
@@ -212,17 +212,15 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Language",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "What have you done?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API Keys used by your class are being managed for you.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/pt-br.json
+++ b/public/languages/pt-br.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Para conjunto de números ou múltipla escolha, escolha \"números\"",
             "NOTES_5": "Para vozes e sons, escolha choose \"sons\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Língua",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Desenhe algo para testar o seu modelo",
         "TEST_WEBCAM": "Tire uma foto para testar o seu modelo",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "O que você fez?",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": "Treinar modelos de aprendizado de máquina para projetos de <span class='mlprojecttype'>imagens</span> usa o <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Falha ao obter suas senhas do seu Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "Falha ao obter suas chaves API do Watson Visual Recognition",
             "USERNAME": "Usuário",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/ru.json
+++ b/public/languages/ru.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Для набора чисел или множественного выбора выберите «числа»",
             "NOTES_5": "Для голосов и звуков выберите «звуки»"
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Язык",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Нарисуйте что-нибудь для тестирования своей модели",
         "TEST_WEBCAM": "Сделайте фото, чтобы протестировать модель",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Что Вы сделали?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API Keys used by your class are being managed for you.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Не удалось получить пароли Watson Assistant",
             "ERROR_FETCHING_VISUALRECOG": "Не удалось получить ключи API визуального распознавания",
             "USERNAME": "Имя пользователя",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/si-lk.json
+++ b/public/languages/si-lk.json
@@ -212,17 +212,15 @@
             "NOTES_4": "ඉලක්කම් වල එකතූන් හෝ බහුවරණ සදහා \"numbers\" තෝරන්න",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "භාෂාව",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "ඔබ කුමක්ද කළේ?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API Keys used by your class are being managed for you.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/conversation/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/sv-se.json
+++ b/public/languages/sv-se.json
@@ -212,17 +212,15 @@
             "NOTES_4": "Välj \"siffror\" för uppsättningar med siffror eller lista med val",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Language",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Vad har du gjort?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "API-nycklarna som används av din klass hanteras åt dig.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/tr.json
+++ b/public/languages/tr.json
@@ -212,17 +212,15 @@
             "NOTES_4": "For sets of numbers or multiple choices, choose \"numbers\"",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "Language",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "Neler yaptınız?",
@@ -1480,9 +1478,10 @@
             "MANAGEDCLASS": "Sınıfınızın kullandığı API Anahtarları sizin için yönetiliyor.",
             "HELP_STEPBYSTEP_GUIDE": "If you're not sure what to do here, please follow the <a href='/apikeys-guide'> step-by-step guide </a>. If you'd like any help, please <strong><a style='cursor: pointer;' href='/help'>get in touch</a></strong>.",
             "INTRO_WATSONASSISTANT": "Training machine learning models for <span class='mlprojecttype'>text</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/cloud/watson-assistant/'>Watson Assistant</a>",
-            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
+            "INTRO_VISUALRECOGNITION": "Training machine learning models for <span class='mlprojecttype'>images</span> projects in the cloud uses <a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "Failed to get your Watson Assistant passwords",
             "ERROR_FETCHING_VISUALRECOG": "Failed to get your Visual Recognition API keys",
             "USERNAME": "Username",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/zh-cn.json
+++ b/public/languages/zh-cn.json
@@ -212,17 +212,15 @@
             "NOTES_4": "对于数字组或多个选项,请选择\"数字\" ",
             "NOTES_5": "For voices and sounds, choose \"sounds\""
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" ?",
-            "NOTES_1": "If you choose \"<strong style='color:black'>images</strong>\" your machine learning model will be trained on cloud servers.",
-            "NOTES_2": "If you choose \"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" your machine learning model will be trained on your own computer.",
-            "NOTES_3": "\"<strong style='color:black'>images</strong>\" is good because:",
-            "NOTES_4": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "NOTES_5": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
-            "NOTES_6": "But, it takes minutes to train while you wait for your turn on the cloud server.",
-            "NOTES_7": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
-            "NOTES_8": "It can be much quicker to train, because you don't have to wait for your turn on the cloud server.",
-            "NOTES_9": "But, it can only be used for Scratch projects."
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "语言",
@@ -386,8 +384,8 @@
         "TEST_CANVAS": "Draw something to test your model with",
         "TEST_WEBCAM": "Take a photo to test your model with",
         "CHANGETYPE": {
-            "IMAGES": "Change to \"images\" so models will be trained in the cloud",
-            "IMGTFJS": "Change to \"images <span class='badge mltinybadge'>beta</span>\" so models will be trained on your computer"
+            "IMAGES": "Change to train models in the cloud",
+            "IMGTFJS": "Change to train models on your computer"
         },
         "WHATHAVEYOUDONE": {
             "TITLE": "你做了什么？",
@@ -1483,6 +1481,7 @@
             "INTRO_VISUALRECOGNITION": " <span class ='mlprojecttype'> images </ span>项目的训练机器学习模型使用<a class ='mlprojecttype' href ='https://www.ibm.com/watson/services/visual-recognition'> Watson Visual Recognition </a> ",
             "INTRO_NUMBERS": "Training machine learning models for <span class='mlprojecttype'>numbers</span> projects does <strong>not</strong> require any API keys",
             "INTRO_SOUNDS": "Training machine learning models for <span class='mlprojecttype'>sound</span> projects does <strong>not</strong> require any API keys",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "无法获取您的Watson助手密码",
             "ERROR_FETCHING_VISUALRECOG": "无法获取您的Visual Recognition API密钥",
             "USERNAME": "用户名",
@@ -1627,22 +1626,19 @@
         },
         "PROJECTS": {
             "TITLE": "Project questions",
-            "Q1": "What is the difference between \"images\" and \"images <span class='mltinybadge badge'>beta</span>\" projects?",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "These can both be used to create the same sort of machine learning projects. The difference is where the models are created and stored.",
-            "Q1-A-2": "In \"<strong>images</strong>\" projects, machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
-            "Q1-A-3": "In \"<strong>images <span class='mltinybadge badge'>beta</span></strong>\" projects, machine learning models are trained on the student's own computer, in the web browser.",
-            "Q1-A-4": "\"<strong>images</strong>\" is good because:",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "It can be used for projects in Scratch, App Inventor, or Python.",
-            "Q1-A-6": "It doesn't matter if your computer is slow, as the model is trained in the cloud.",
             "Q1-A-7": "It can create models that are more accurate, particularly when using a small number of training examples.",
-            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server, and (for unmanaged classes) requires a Watson API key from IBM Cloud.",
-            "Q1-A-9": "\"<strong style='color:black'>images <span class='mltinybadge badge'>beta</span></strong>\" is good because:",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "It can be much quicker to train, because it starts training immediately without waiting for a turn on the cloud server.",
-            "Q1-A-11": "It doesn't require any IBM Cloud API keys (for unmanaged classes).",
             "Q1-A-12": "Models do not need to be automatically deleted.",
-            "Q1-A-13": "But, it can only be used for Scratch projects, and requires the student to be using a reasonably fast computer.",
-            "Q1-A-14": "Training in the browser is described as a beta because it is a new feature on the site, and may still have problems with some operating systems or web browsers. If you encounter errors, please report these in <a href='https://groups.google.com/d/forum/mlforkids'>the ML for Kids forum</a>.",
-            "Q2": "How can you change an \"images\" project to be an \"images <span class='mltinybadge badge'>beta</span>\" project (and vice versa)?",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "You can change between the two modes from the \"Learn & Test\" page for your project.",
             "Q2-A-2": "The link to do this is in top-right of the page.",
             "Q2-A-3": "Any existing machine learning models for the project will be deleted if this is done.",

--- a/public/languages/zh-tw.json
+++ b/public/languages/zh-tw.json
@@ -212,17 +212,15 @@
             "NOTES_4": "一系列的數字或多個選項，請選擇「數字」",
             "NOTES_5": "聲音與音樂，請選擇「聲音」"
         },
-        "EXPLAINTYPES": {
-            "NOTICE": "「圖片」與「圖片<span class='mltinybadge badge'>beta</span>」有什麼差異？",
-            "NOTES_1": "如果你選擇「<strong style='color:black'>圖片</strong>」，你的機器學習模型將在雲端伺服器上訓練。",
-            "NOTES_2": "如果你選擇「<strong style='color:black'>圖片<span class='mltinybadge badge'>beta</span></strong>」，你的機器學習模型將在你自己的電腦上訓練。",
-            "NOTES_3": "「<strong style='color:black'>圖片</strong>」的優點包含：",
-            "NOTES_4": "成果可以運用在Scratch、App inventor或是Python的專案中",
-            "NOTES_5": "即使你電腦的效能也差也沒關係，因為模型在雲端上訓練。",
-            "NOTES_6": "但是，他會花較多時間等待雲端伺服器開始訓練你的模型。",
-            "NOTES_7": "「<strong style='color:black'>圖片<span class='mltinybadge badge'>beta</span></strong>」的優點包含：",
-            "NOTES_8": "可以更快速的完成模型訓練，因為你不需要等待雲端伺服器開始訓練。",
-            "NOTES_9": "但是，成果只能運用在Scratch的專案中"
+        "IMAGEPROJECTS": {
+            "LABEL": "Where to train the model",
+            "TYPES": {
+                "IMAGES": "in the cloud",
+                "IMGTFJS": "on your computer"
+            },
+            "NOTES_1": "If you choose \"on your computer\" you can only use the model in Scratch.",
+            "NOTES_2": "If you choose \"in the cloud\" you can use the model in Scratch, Python, or App Inventor.",
+            "NOTES_3": "You can change your mind about this at any time."
         },
         "LANGUAGE": {
             "LABEL": "語言",
@@ -1521,6 +1519,7 @@
             "INTRO_VISUALRECOGNITION": "使用<a class='mlprojecttype' href='https://www.ibm.com/watson/services/visual-recognition/'>Watson Visual Recognition</a>來訓練<span class='mlprojecttype'>圖片</span>專案的機器學習模型",
             "INTRO_NUMBERS": "<strong>不需要</strong>任何API密碼即可訓練<span class='mlprojecttype'>數字</span>專案的機器學習模型",
             "INTRO_SOUNDS": "<strong>不需要</strong>任何API密碼即可訓練<span class='mlprojecttype'>聲音</span>專案的機器學習模型",
+            "INTRO_IMAGES": "Training machine learning models for <span class='mlprojecttype'>images</span> projects does <strong>not</strong> require any API keys",
             "ERROR_FETCHING_WATSONASSISTANT": "無法取得你的Watson Assistant密碼",
             "ERROR_FETCHING_VISUALRECOG": "無法取得你的Visual Recognition的API密碼",
             "USERNAME": "使用者名稱",
@@ -1667,23 +1666,20 @@
         "PROJECTS": {
             "TITLE": "專案問題",
 
-            "Q1": "圖片專案與圖片<span class='mltinybadge badge'>beta</span>專案有什麼差別？",
+            "Q1": "What is the difference between training image models \"on your computer\" or \"in the cloud\"?",
             "Q1-A-1": "這兩種都可以用來建立相同種類的機器學習專案。不同的地方在於在哪裡建立與儲存模型。",
-            "Q1-A-2": "在<strong>圖片</strong>專案中，機器學習模型將在雲端伺服器訓練，透過Watson視覺辨識的線上服務達成。",
-            "Q1-A-3": "在<strong>圖片<span class='mltinybadge badge'>beta</span></strong>專案中，機器學習模型將在你自己電腦的網頁瀏覽器中訓練。",
-            "Q1-A-4": "<strong>圖片</strong>專案的優點是：",
+            "Q1-A-2": "If you choose \"<strong>in the cloud</strong>\" machine learning models are trained on cloud servers using an online service called Watson Visual Recognition.",
+            "Q1-A-3": "If you choose \"<strong>on your computer</strong>\" machine learning models are trained on the student's own computer, in the web browser.",
+            "Q1-A-4": "\"<strong>in the cloud</strong>\" is good because:",
             "Q1-A-5": "可以運用在Scratch、App inventor或是Python的專案中",
-            "Q1-A-6": "即使你電腦的效能也差也沒關係，因為模型在雲端上訓練。",
             "Q1-A-7": "它可以建立更準確的模型，尤其是在使用少量訓練範例時。",
-            "Q1-A-8": "但是，等待開始雲端服務器訓練時需要花幾分鐘的時間，並且需要IBM Cloud的Watson API密碼（沒有班級管理的帳戶）",
-            "Q1-A-9": "「<strong style='color:black'>圖片<span class='mltinybadge badge'>beta</span></strong>」的優點包含：",
+            "Q1-A-8": "But, it takes several minutes to train while you wait for your turn on the cloud server.",
+            "Q1-A-9": "\"<strong>on your computer</strong>\" is good because:",
             "Q1-A-10": "它可以更快地完成訓練，因為它可以馬上開始，不需等待開啟雲端服務器的時間。",
-            "Q1-A-11": "他不需要任何IBM Cloud的API密碼（對於沒有班級管理的帳戶）",
             "Q1-A-12": "模型不會被自動刪除",
-            "Q1-A-13": "但是，這只能用在Scratch專案中，而且需要學生使用效能夠快的電腦。",
-            "Q1-A-14": "因為在網頁瀏覽器中訓練是新功能所以我們稱為beta。因此可能仍有一些操作環境或瀏覽器的問題。如果你發生錯誤，請回報問題到<a href='https://groups.google.com/d/forum/mlforkids'>兒童機器學習論壇</a>。",
+            "Q1-A-13": "But, it can only be used for Scratch projects.",
 
-            "Q2": "如何將「圖片專案」切換成「圖片<span class='mltinybadge badge'>beta</span>專案」？（反之亦同）",
+            "Q2": "How can you change an \"images\" project to train in the cloud, or to train on your computer?",
             "Q2-A-1": "你可以在專案中的訓練頁面切換這兩種模式。",
             "Q2-A-2": "切換的連結在畫面的右上方。",
             "Q2-A-3": "完成後將刪除此專案中所有既有的機器學習模型。",

--- a/src/tests/restapi/tenants.ts
+++ b/src/tests/restapi/tenants.ts
@@ -66,6 +66,56 @@ describe('REST API - tenants', () => {
     });
 
 
+    describe('get policy', () => {
+
+        it('should only allow students to query project types', () => {
+            const tenant = uuid();
+            const url = '/api/classes/' + tenant + '/policy';
+            nextAuth0UserTenant = tenant;
+            nextAuth0UserRole = 'student';
+            return request(testServer)
+                .get(url)
+                .expect(httpstatus.OK)
+                .then((res) => {
+                    assert.deepStrictEqual(Object.keys(res.body),
+                        [ 'supportedProjectTypes' ]);
+                    assert.deepStrictEqual(res.body.supportedProjectTypes,
+                        [ 'text', 'images', 'numbers', 'sounds', 'imgtfjs' ]);
+                });
+        });
+
+        it('should allow teachers to query detailed policy info', () => {
+            const tenant = uuid();
+            const url = '/api/classes/' + tenant + '/policy';
+            nextAuth0UserTenant = tenant;
+            nextAuth0UserRole = 'supervisor';
+            return request(testServer)
+                .get(url)
+                .expect(httpstatus.OK)
+                .then((res) => {
+                    assert.deepStrictEqual(Object.keys(res.body),
+                        [
+                            'isManaged',
+                            'tenantType',
+                            'maxTextModels',
+                            'maxImageModels',
+                            'maxUsers',
+                            'supportedProjectTypes',
+                            'maxProjectsPerUser',
+                            'textClassifierExpiry',
+                            'imageClassifierExpiry',
+                            'textTrainingItemsPerProject',
+                            'numberTrainingItemsPerProject',
+                            'numberTrainingItemsPerClassProject',
+                            'imageTrainingItemsPerProject',
+                            'soundTrainingItemsPerProject',
+                        ]);
+                    assert.deepStrictEqual(res.body.supportedProjectTypes,
+                        [ 'text', 'images', 'numbers', 'sounds', 'imgtfjs' ]);
+                });
+        });
+    });
+
 
     describe('set policy', () => {
 


### PR DESCRIPTION
Now that Visual Recognition service has been deprecated, I need
to start down a path of removing it from the site. This commit
lays the groundwork for me to be able to remove 'images' projects
from any new classes, while still leaving it for classes who
already have existing VR API keys.

Contributes to: #374

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>