### PR TITLE
Try to get enviroment camera by default

### DIFF
--- a/mlforkids-api/public/components/models/models.controller.js
+++ b/mlforkids-api/public/components/models/models.controller.js
@@ -735,6 +735,10 @@
                     $scope.channel = {};
                     $scope.webcamerror = false;
                     $scope.webcamInitComplete = false;
+                    $scope.webcamConfig = {
+                        video: { facingMode: { exact: "environment" } }
+                    };
+                    $scope.fallbackTried = false;
 
                     $scope.webcamCanvas = null;
 
@@ -770,6 +774,19 @@
 
                     $scope.onWebcamError = function(err) {
                         loggerService.error('[ml4kmodels] on webcam error', err);
+
+                        if (!$scope.fallbackTried) {
+                            $scope.fallbackTried = true;
+
+                            $scope.webcamConfig = {
+                                video: { facingMode: { exact: "user" } }
+                            };
+
+                            $scope.$apply();
+                        } else {
+                            $scope.webcamerror = true;
+                            $scope.$apply();
+                        }
 
                         $scope.webcamInitComplete = true;
 

--- a/mlforkids-api/public/components/models/webcam.tmpl.html
+++ b/mlforkids-api/public/components/models/webcam.tmpl.html
@@ -8,6 +8,7 @@
         <img src="static/images/loading.gif" ng-hide="webcamInitComplete" alt="loading" style="margin: 1em auto; width: 320px;"/>
         <webcam
             channel="channel"
+            config="webcamConfig"
             ng-hide="webcamerror"
             on-error="onWebcamError(err)"
             on-access-denied="onWebcamError(err)"

--- a/mlforkids-api/public/components/training/training.controller.js
+++ b/mlforkids-api/public/components/training/training.controller.js
@@ -555,6 +555,10 @@
                     $scope.channel = {};
                     $scope.webcamerror = false;
                     $scope.webcamInitComplete = false;
+                    $scope.webcamConfig = {
+                        video: { facingMode: { exact: "environment" } }
+                    };
+                    $scope.fallbackTried = false;
 
                     $scope.webcamCanvas = null;
 
@@ -594,6 +598,20 @@
 
                     $scope.onWebcamError = function(err) {
                         loggerService.error('[ml4ktraining] webcam error', err);
+
+                        if (!$scope.fallbackTried) {
+                            $scope.fallbackTried = true;
+
+                            $scope.webcamConfig = {
+                                video: { facingMode: { exact: "user" } }
+                            };
+
+                            $scope.$apply();
+                        } else {
+                            $scope.webcamerror = true;
+                            $scope.$apply();
+                        }
+
 
                         $scope.webcamInitComplete = true;
 

--- a/mlforkids-api/public/components/training/webcam.tmpl.html
+++ b/mlforkids-api/public/components/training/webcam.tmpl.html
@@ -8,6 +8,7 @@
         <img src="static/images/loading.gif" ng-hide="webcamInitComplete" alt="loading" style="margin: 1em auto; width: 320px;"/>
         <webcam
             channel="channel"
+            config="webcamConfig"
             ng-hide="webcamerror"
             on-error="onWebcamError(err)"
             on-access-denied="onWebcamError(err)"


### PR DESCRIPTION
This propousal tryes to solve a problem when using mobile devices with multiple cameras. By default, the web browser use the front camera but I am sure it would by more usefull if the default for mobile devices is rear camera. It is easy to take pictures for both training and testing.

The code changes forces the browser to use enviroment (rear) camera. If it fails because the device hasn't got a rear camera it changes the config to user camera (front/webcam).