### PR TITLE
fix: handle image decode/resize failures in imageToolsService

### DIFF
--- a/mlforkids-api/karma.conf.js
+++ b/mlforkids-api/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function (config) {
             'public/components/newproject/*.js',
             'public/components/teacher_students/*.js',
             'public/components/utils/*.js',
+            'public/third-party/webcam-directive/*.js',
 
             // loaded into $templateCache (via ngHtml2JsPreprocessor below) so
             // DOM-level tests can compile fragments of the *real* template

--- a/mlforkids-api/karma.conf.js
+++ b/mlforkids-api/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function (config) {
             'public/components/projects/*.js',
             'public/components/newproject/*.js',
             'public/components/teacher_students/*.js',
+            'public/components/utils/*.js',
 
             // loaded into $templateCache (via ngHtml2JsPreprocessor below) so
             // DOM-level tests can compile fragments of the *real* template

--- a/mlforkids-api/public/components/utils/imagetools.service.js
+++ b/mlforkids-api/public/components/utils/imagetools.service.js
@@ -14,32 +14,42 @@
         const MAX_SIZE = 224;
 
         function getDataFromImageSource(imagesource, format) {
-            return $q(function (resolve) {
-                // --- calculate dimensions of the image
-                var width = imagesource.width;
-                var height = imagesource.height;
-                if (width > height) {
-                    if (width > MAX_SIZE) {
-                        height = height * (MAX_SIZE / width);
-                        width = MAX_SIZE;
+            return $q(function (resolve, reject) {
+                try {
+                    // --- calculate dimensions of the image
+                    var width = imagesource.width;
+                    var height = imagesource.height;
+                    if (width > height) {
+                        if (width > MAX_SIZE) {
+                            height = height * (MAX_SIZE / width);
+                            width = MAX_SIZE;
+                        }
                     }
-                }
-                else if (height > MAX_SIZE) {
-                    width = width * (MAX_SIZE / height);
-                    height = MAX_SIZE;
-                }
+                    else if (height > MAX_SIZE) {
+                        width = width * (MAX_SIZE / height);
+                        height = MAX_SIZE;
+                    }
 
-                // --- resize the image
-                var hiddenCanvas = document.createElement('canvas');
-                hiddenCanvas.width = width;
-                hiddenCanvas.height = height;
-                var ctx = hiddenCanvas.getContext('2d');
-                ctx.drawImage(imagesource, 0, 0, width, height);
+                    // --- resize the image
+                    var hiddenCanvas = document.createElement('canvas');
+                    hiddenCanvas.width = width;
+                    hiddenCanvas.height = height;
+                    var ctx = hiddenCanvas.getContext('2d');
+                    ctx.drawImage(imagesource, 0, 0, width, height);
 
-                // --- get resized image data
-                hiddenCanvas.toBlob(function (output) {
-                    resolve(output);
-                }, format);
+                    // --- get resized image data
+                    hiddenCanvas.toBlob(function (output) {
+                        if (output) {
+                            resolve(output);
+                        }
+                        else {
+                            reject(new Error('Unable to create image data from file'));
+                        }
+                    }, format);
+                }
+                catch (resizeErr) {
+                    reject(resizeErr);
+                }
             });
         }
 
@@ -56,7 +66,13 @@
                             getDataFromImageSource(resizedImg, file.type)
                                 .then(function (data) {
                                     resolve(data);
+                                })
+                                .catch(function (resizeErr) {
+                                    reject(resizeErr);
                                 });
+                        };
+                        resizedImg.onerror = function (imageErr) {
+                            reject(imageErr);
                         };
                         resizedImg.src = imageFileReader.result;
                     };

--- a/mlforkids-api/public/components/utils/imagetools.service.spec.js
+++ b/mlforkids-api/public/components/utils/imagetools.service.spec.js
@@ -1,0 +1,193 @@
+describe('imageToolsService', function () {
+
+    var $rootScope;
+    var imageToolsService;
+    var readersServiceMock;
+
+    var fakeReader;
+    var fakeImg;
+    var fakeCanvas;
+    var fakeCtx;
+    var originalCreateElement;
+
+    beforeEach(function () {
+        fakeReader = { readAsDataURL : function () {}, result : 'data:image/png;base64,ZmFrZQ==' };
+        readersServiceMock = jasmine.createSpyObj('readersService', ['createFileReader']);
+        readersServiceMock.createFileReader.and.returnValue(fakeReader);
+
+        module('app', function ($provide) {
+            $provide.value('readersService', readersServiceMock);
+        });
+
+        inject(function (_$rootScope_, _imageToolsService_) {
+            $rootScope = _$rootScope_;
+            imageToolsService = _imageToolsService_;
+        });
+
+        fakeImg = { width : 300, height : 200 };
+
+        fakeCtx = jasmine.createSpyObj('ctx', ['drawImage']);
+        fakeCanvas = {
+            getContext : function () { return fakeCtx; },
+            toBlob : function (callback) { callback({ fake : 'blob' }); }
+        };
+
+        originalCreateElement = document.createElement;
+        spyOn(document, 'createElement').and.callFake(function (tagName) {
+            if (tagName === 'img') {
+                return fakeImg;
+            }
+            if (tagName === 'canvas') {
+                return fakeCanvas;
+            }
+            return originalCreateElement.call(document, tagName);
+        });
+    });
+
+
+    it('resolves with the resized image data for a valid image', function () {
+        var file = { type : 'image/png' };
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        imageFileReaderLoaded();
+        fakeImg.onload();
+        $rootScope.$digest();
+
+        expect(error).toBeUndefined();
+        expect(result).toEqual({ fake : 'blob' });
+    });
+
+
+    it('rejects instead of hanging when the file cannot be decoded as an image', function () {
+        var file = { type : 'image/png' };
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        imageFileReaderLoaded();
+        fakeImg.onerror(new Error('image decode failed'));
+        $rootScope.$digest();
+
+        expect(result).toBeUndefined();
+        expect(error).toBeDefined();
+    });
+
+
+    it('rejects instead of hanging when the browser does not support reading the file', function () {
+        var file = { type : 'image/png' };
+        var unsupportedErr = new Error('File upload is not supported in this browser.');
+        readersServiceMock.createFileReader.and.callFake(function () {
+            throw unsupportedErr;
+        });
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        $rootScope.$digest();
+
+        expect(result).toBeUndefined();
+        expect(error).toBe(unsupportedErr);
+    });
+
+
+    it('rejects instead of hanging when the FileReader itself fails to read the file', function () {
+        var file = { type : 'image/png' };
+        var readErr = new Error('could not read file');
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        fakeReader.onerror(readErr);
+        $rootScope.$digest();
+
+        expect(result).toBeUndefined();
+        expect(error).toBe(readErr);
+    });
+
+
+    it('rejects instead of hanging when resizing the image fails', function () {
+        var file = { type : 'image/png' };
+        fakeCtx.drawImage.and.callFake(function () {
+            throw new Error('drawImage failed');
+        });
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        imageFileReaderLoaded();
+        fakeImg.onload();
+        $rootScope.$digest();
+
+        expect(result).toBeUndefined();
+        expect(error).toBeDefined();
+    });
+
+
+    it('rejects instead of hanging when the canvas cannot produce image data', function () {
+        var file = { type : 'image/png' };
+        fakeCanvas.toBlob = function (callback) { callback(null); };
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        imageFileReaderLoaded();
+        fakeImg.onload();
+        $rootScope.$digest();
+
+        expect(result).toBeUndefined();
+        expect(error).toBeDefined();
+    });
+
+
+    it('resolves without error for an image reported with zero dimensions', function () {
+        var file = { type : 'image/png' };
+        fakeImg.width = 0;
+        fakeImg.height = 0;
+
+        var result;
+        var error;
+        imageToolsService.getDataFromFile(file).then(
+            function (data) { result = data; },
+            function (err) { error = err; }
+        );
+
+        imageFileReaderLoaded();
+        fakeImg.onload();
+        $rootScope.$digest();
+
+        expect(error).toBeUndefined();
+        expect(result).toEqual({ fake : 'blob' });
+    });
+
+
+    function imageFileReaderLoaded() {
+        fakeReader.onloadend();
+    }
+
+});

--- a/mlforkids-api/public/third-party/webcam-directive/README.md
+++ b/mlforkids-api/public/third-party/webcam-directive/README.md
@@ -1,1 +1,6 @@
 based on https://github.com/jonashartmann/webcam-directive modified to allow custom video options
+
+Also modified so that a rejected `videoElem.play()` promise (e.g. `NotAllowedError`
+when a user denies camera permission) is routed to the directive's existing
+`onFailure`/`onError` handler, instead of being left as an unhandled promise
+rejection.

--- a/mlforkids-api/public/third-party/webcam-directive/webcam.js
+++ b/mlforkids-api/public/third-party/webcam-directive/webcam.js
@@ -98,7 +98,10 @@ angular.module('webcam', [])
           }
 
           /* Start playing the video to show the stream from the webcam */
-          videoElem.play();
+          var playPromise = videoElem.play();
+          if (playPromise && typeof playPromise.catch === 'function') {
+            playPromise.catch(onFailure);
+          }
           $scope.config.video = videoElem;
 
           /* Call custom callback */

--- a/mlforkids-api/public/third-party/webcam-directive/webcam.spec.js
+++ b/mlforkids-api/public/third-party/webcam-directive/webcam.spec.js
@@ -1,0 +1,87 @@
+describe('webcam directive', function () {
+
+    var $compile;
+    var $rootScope;
+    var getUserMediaResult;
+
+    beforeEach(function () {
+        module('webcam');
+
+        inject(function (_$compile_, _$rootScope_) {
+            $compile = _$compile_;
+            $rootScope = _$rootScope_;
+        });
+
+        getUserMediaResult = {
+            then : function (onFulfilled) { this._onFulfilled = onFulfilled; return this; },
+            catch : function (onRejected) { this._onRejected = onRejected; return this; }
+        };
+        spyOn(navigator, 'getMedia').and.returnValue(getUserMediaResult);
+    });
+
+
+    function compileDirective(onError, onStream) {
+        var scope = $rootScope.$new();
+        scope.config = {};
+        scope.handleError = onError || function () {};
+        scope.handleStream = onStream || function () {};
+
+        var element = $compile(
+            '<webcam channel="config" on-error="handleError(err)" on-stream="handleStream()"></webcam>'
+        )(scope);
+        scope.$digest();
+        return element;
+    }
+
+
+    it('routes a rejected video.play() promise to onError instead of leaving it unhandled', function () {
+        var playResult = {
+            catch : function (onRejected) { this._onRejected = onRejected; return this; }
+        };
+        spyOn(HTMLMediaElement.prototype, 'play').and.returnValue(playResult);
+
+        var onError = jasmine.createSpy('onError');
+        compileDirective(onError);
+        getUserMediaResult._onFulfilled(new MediaStream());
+
+        var playRejection = new Error(
+            'The request is not allowed by the user agent or the platform in the current context, ' +
+            'possibly because the user denied permission.'
+        );
+        playRejection.name = 'NotAllowedError';
+        playResult._onRejected(playRejection);
+
+        expect(onError).toHaveBeenCalledWith(playRejection);
+    });
+
+
+    it('does not call onError when video.play() resolves normally', function () {
+        var playResult = {
+            catch : function () { return this; }
+        };
+        spyOn(HTMLMediaElement.prototype, 'play').and.returnValue(playResult);
+
+        var onError = jasmine.createSpy('onError');
+        var onStream = jasmine.createSpy('onStream');
+        compileDirective(onError, onStream);
+        getUserMediaResult._onFulfilled(new MediaStream());
+
+        expect(onError).not.toHaveBeenCalled();
+        expect(onStream).toHaveBeenCalled();
+    });
+
+
+    it('does not throw when video.play() does not return a promise (older browsers)', function () {
+        spyOn(HTMLMediaElement.prototype, 'play').and.returnValue(undefined);
+
+        var onError = jasmine.createSpy('onError');
+
+        expect(function () {
+            compileDirective(onError);
+            getUserMediaResult._onFulfilled(new MediaStream());
+        }).not.toThrow();
+
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+});


### PR DESCRIPTION
getDataFromFile() left its promise permanently pending when a file couldn't be decoded as an image (no img.onerror handler), when resizing threw synchronously (no try/catch around the $q executor - AngularJS's $q, unlike native Promises, doesn't auto-catch), or when canvas.toBlob produced no output. Callers like the training page's image upload got no example added and no error shown.

Adds Karma specs covering the valid-image path and each failure mode, and registers public/components/utils/*.js with karma.conf.js so they run.