### PR TITLE
fix(api): resolve pre-existing ESLint errors

### DIFF
--- a/mlforkids-api/src/lib/restapi/auth.ts
+++ b/mlforkids-api/src/lib/restapi/auth.ts
@@ -85,7 +85,7 @@ async function sessionusersAuthenticate(
     try {
         decoded = jwtDecode(jwtTokenString);
     }
-    catch (err) {
+    catch {
         return errors.notAuthorised(res);
     }
 

--- a/mlforkids-api/src/tests/restapi/localprojects.ts
+++ b/mlforkids-api/src/tests/restapi/localprojects.ts
@@ -541,7 +541,7 @@ describe('REST API - local projects', () => {
                     { id : 3, numberdata : [ 3, 3 ], label : 'one' },
                     { id : 4, numberdata : [ 1, 10 ], label : 'two' },
                     { id : 5, numberdata : [ 2, 20 ], label : 'two' },
-                    { id : 6, numberdata : [ 3, 999999999999999999999999999999999999999999999999999 ], label : 'two' },
+                    { id : 6, numberdata : [ 3, 1e51 ], label : 'two' },
                 ])
                 .expect(httpstatus.CREATED);
 
@@ -561,7 +561,7 @@ describe('REST API - local projects', () => {
                     { id : 3, numberdata : [ 3, 3 ], label : 'one' },
                     { id : 4, numberdata : [ 1, 10 ], label : 'two' },
                     { id : 5, numberdata : [ 2, 20 ], label : 'two' },
-                    { id : 6, numberdata : [ 3, -999999999999999999999999999999999999999999999999999 ], label : 'two' },
+                    { id : 6, numberdata : [ 3, -1e51 ], label : 'two' },
                 ])
                 .expect(httpstatus.CREATED);
 

--- a/mlforkids-api/test/karma/fake-app-module.js
+++ b/mlforkids-api/test/karma/fake-app-module.js
@@ -1,3 +1,4 @@
+/* global angular */
 // Minimal stand-in for the real 'app' module (defined in public/app.js).
 //
 // The real module depends on ngMaterial, ui.router, pascalprecht.translate


### PR DESCRIPTION
## Summary of Changes
- **`auth.ts`**: Omitted unused parameter in `catch (err)` block (`@typescript-eslint/no-unused-vars`).
- **`localprojects.ts`**: Converted oversized integer literals to scientific notation (`1e51` / `-1e51`) to resolve `no-loss-of-precision` violations while preserving test logic.
- **`fake-app-module.js`**: Added `/* global angular */` header directive to resolve Karma test mock `no-undef` error.

## Verification
- `npm run lint` passed with 0 errors.
- `npm run compile` passed cleanly.