### PR TITLE
Add ops script to set a tenant's max users limit

### DIFF
--- a/mlforkids-api/src/lib/db/objects.ts
+++ b/mlforkids-api/src/lib/db/objects.ts
@@ -1099,6 +1099,31 @@ export function setClassTenantExpiries(
 }
 
 
+export function setClassTenantMaxUsers(
+    tenant: Objects.ClassTenant,
+    maxusers: number,
+): Objects.ClassTenant
+{
+    if (!tenant) {
+        throw new Error('Missing tenant info to update');
+    }
+    if (!maxusers) {
+        throw new Error('Missing required max users value');
+    }
+    if (!Number.isInteger(maxusers)) {
+        throw new Error('Max users values should be an integer');
+    }
+    if (maxusers < 1) {
+        throw new Error('Max users values should be a positive number');
+    }
+    if (maxusers > 399) {
+        throw new Error('Max users values should not be greater than 399');
+    }
+
+    return { ...tenant, maxUsers : maxusers };
+}
+
+
 
 
 // -----------------------------------------------------------------------------

--- a/mlforkids-api/src/lib/db/store.ts
+++ b/mlforkids-api/src/lib/db/store.ts
@@ -2498,8 +2498,7 @@ export async function modifyClassTenantMaxUsers(
     ];
 
     const response = await dbExecute(queryName, queryString, queryValues);
-    if (response.rowCount !== 1 &&  // row inserted
-        response.rowCount !== 2)    // row updated
+    if (response.rowCount !== 1)
     {
         log.error({ response, queryValues }, 'Failed to update tenant info');
         throw new Error('Failed to update tenant info');

--- a/mlforkids-api/src/lib/db/store.ts
+++ b/mlforkids-api/src/lib/db/store.ts
@@ -2469,6 +2469,46 @@ export async function modifyClassTenantExpiries(
 }
 
 
+export async function modifyClassTenantMaxUsers(
+    classid: string,
+    maxusers: number,
+): Promise<Objects.ClassTenant>
+{
+    const tenantinfo = await getClassTenant(classid);
+
+    const modified = dbobjects.setClassTenantMaxUsers(tenantinfo, maxusers);
+    const obj = dbobjects.getClassDbRow(modified);
+
+    const queryName = 'dbqn-insert-tenants-maxusers';
+    const queryString = 'INSERT INTO tenants ' +
+                            '(id, projecttypes, ' +
+                                'maxusers, maxprojectsperuser, ' +
+                                'textclassifiersexpiry, ' +
+                                'ismanaged) ' +
+                            'VALUES ($1, $2, $3, $4, $5, $6) ' +
+                            'ON CONFLICT(id) DO UPDATE SET ' +
+                                'maxusers = $7';
+    const queryValues = [
+        obj.id, obj.projecttypes,
+        obj.maxusers, obj.maxprojectsperuser,
+        obj.textclassifiersexpiry,
+        obj.ismanaged,
+        //
+        obj.maxusers,
+    ];
+
+    const response = await dbExecute(queryName, queryString, queryValues);
+    if (response.rowCount !== 1 &&  // row inserted
+        response.rowCount !== 2)    // row updated
+    {
+        log.error({ response, queryValues }, 'Failed to update tenant info');
+        throw new Error('Failed to update tenant info');
+    }
+
+    return modified;
+}
+
+
 export async function deleteClassTenant(classid: string): Promise<void>
 {
     const queryName = 'dbqn-delete-tenants-id';

--- a/mlforkids-api/src/ops/set-tenant-maxusers.ts
+++ b/mlforkids-api/src/ops/set-tenant-maxusers.ts
@@ -1,0 +1,33 @@
+/* eslint no-console: 0 */
+/* tslint:disable: no-console max-line-length */
+import * as store from '../lib/db/store';
+
+const opsArgs = process.argv.slice(2);
+
+if (opsArgs.length !== 2) {
+    console.log('usage: node set-tenant-maxusers.js tenantid maxusers');
+    process.exit(-1); // eslint-disable-line
+}
+
+const tenantid = opsArgs[0];
+const maxusers = parseInt(opsArgs[1], 10);
+
+console.log('tenant    :', tenantid);
+console.log('max users :', maxusers);
+
+console.log('');
+console.log('connecting to DB...');
+store.init()
+    .then(() => {
+        console.log('updating tenant max users...');
+        return store.modifyClassTenantMaxUsers(tenantid, maxusers);
+    })
+    .then((tenant) => {
+        console.log('done:', tenant);
+    })
+    .catch((err) => {
+        console.error(err);
+    })
+    .finally(() => {
+        return store.disconnect();
+    });

--- a/mlforkids-api/src/tests/db/tenantstore.ts
+++ b/mlforkids-api/src/tests/db/tenantstore.ts
@@ -138,4 +138,64 @@ describe('DB store - tenants', () => {
         return store.deleteClassTenant(id);
     });
 
+    it('should modify max users for a non-existent tenant', async () => {
+        const id = uuid();
+        const newclass: Types.ClassTenant = await store.modifyClassTenantMaxUsers(id, 50);
+        assert.deepStrictEqual(newclass, {
+            id,
+            supportedProjectTypes : ['text', 'imgtfjs', 'numbers', 'sounds'],
+            tenantType : Types.ClassTenantType.UnManaged,
+            maxUsers : 50,
+            maxProjectsPerUser : 3,
+            textClassifierExpiry : 24,
+        });
+
+        const fetched: Types.ClassTenant = await store.getClassTenant(id);
+        assert.deepStrictEqual(newclass, fetched);
+
+        await store.deleteClassTenant(id);
+    });
+
+    it('should modify max users for an existing tenant', async () => {
+        const id = uuid();
+        const created: Types.ClassTenant = await store.modifyClassTenantExpiries(id, 6);
+        assert.strictEqual(created.maxUsers, 31);
+
+        const updated: Types.ClassTenant = await store.modifyClassTenantMaxUsers(id, 75);
+        assert.deepStrictEqual(updated, {
+            id,
+            supportedProjectTypes : ['text', 'imgtfjs', 'numbers', 'sounds'],
+            tenantType : Types.ClassTenantType.UnManaged,
+            maxUsers : 75,
+            maxProjectsPerUser : 3,
+            textClassifierExpiry : 6,
+        });
+
+        const fetched: Types.ClassTenant = await store.getClassTenant(id);
+        assert.deepStrictEqual(fetched, updated);
+
+        await store.deleteClassTenant(id);
+    });
+
+    it('should reject invalid max users values', async () => {
+        const id = uuid();
+
+        await assert.rejects(
+            store.modifyClassTenantMaxUsers(id, 0),
+            { message : 'Missing required max users value' },
+        );
+        await assert.rejects(
+            store.modifyClassTenantMaxUsers(id, -5),
+            { message : 'Max users values should be a positive number' },
+        );
+        await assert.rejects(
+            store.modifyClassTenantMaxUsers(id, 1.5),
+            { message : 'Max users values should be an integer' },
+        );
+        await assert.rejects(
+            store.modifyClassTenantMaxUsers(id, 400),
+            { message : 'Max users values should not be greater than 399' },
+        );
+    });
+
 });

--- a/mlforkids-api/src/tests/db/tenantstore.ts
+++ b/mlforkids-api/src/tests/db/tenantstore.ts
@@ -156,10 +156,11 @@ describe('DB store - tenants', () => {
         await store.deleteClassTenant(id);
     });
 
-    it('should modify max users for an existing tenant', async () => {
+    it('should modify max users for an existing unmanaged tenant, without changing its tenant type', async () => {
         const id = uuid();
         const created: Types.ClassTenant = await store.modifyClassTenantExpiries(id, 6);
         assert.strictEqual(created.maxUsers, 31);
+        assert.strictEqual(created.tenantType, Types.ClassTenantType.UnManaged);
 
         const updated: Types.ClassTenant = await store.modifyClassTenantMaxUsers(id, 75);
         assert.deepStrictEqual(updated, {
@@ -169,6 +170,28 @@ describe('DB store - tenants', () => {
             maxUsers : 75,
             maxProjectsPerUser : 3,
             textClassifierExpiry : 6,
+        });
+
+        const fetched: Types.ClassTenant = await store.getClassTenant(id);
+        assert.deepStrictEqual(fetched, updated);
+
+        await store.deleteClassTenant(id);
+    });
+
+    it('should modify max users for an existing managed tenant, without changing its tenant type', async () => {
+        const id = 'thisisthemanagedtenantformaxusers';
+        const created: Types.ClassTenant = await store.storeManagedClassTenant(id, 30, 3, Types.ClassTenantType.ManagedPool);
+        assert.strictEqual(created.maxUsers, 31);
+        assert.strictEqual(created.tenantType, Types.ClassTenantType.ManagedPool);
+
+        const updated: Types.ClassTenant = await store.modifyClassTenantMaxUsers(id, 75);
+        assert.deepStrictEqual(updated, {
+            id,
+            supportedProjectTypes : [ 'text', 'numbers', 'sounds', 'imgtfjs' ],
+            tenantType : Types.ClassTenantType.ManagedPool,
+            maxUsers : 75,
+            maxProjectsPerUser : 3,
+            textClassifierExpiry : 24,
         });
 
         const fetched: Types.ClassTenant = await store.getClassTenant(id);


### PR DESCRIPTION
Adds set-tenant-maxusers.ts, a small admin script for changing the
maxusers value for a tenant. It works whether or not the tenant
already has a row in the tenants table, using the same
INSERT ... ON CONFLICT DO UPDATE pattern as the existing
modifyClassTenantExpiries: an existing row has just its maxusers
column updated, while a tenant with no row yet gets one created from
the default tenant spec with the new maxusers value applied.