### PR TITLE
test(utils): fix postgresql required env vars in env unit test suite

### DIFF
--- a/mlforkids-api/src/tests/utils/env.ts
+++ b/mlforkids-api/src/tests/utils/env.ts
@@ -8,26 +8,37 @@ import * as env from '../../lib/utils/env';
 describe('Utils - env', () => {
 
     let oldDBHost: string | undefined;
+    let oldDBPort: string | undefined;
     let oldDBUser: string | undefined;
+    let oldDBDatabase: string | undefined;
 
     before(() => {
         oldDBHost = process.env.POSTGRESQLHOST;
+        oldDBPort = process.env.POSTGRESQLPORT;
         oldDBUser = process.env.POSTGRESQLUSER;
+        oldDBDatabase = process.env.POSTGRESQLDATABASE;
     });
     after(() => {
         process.env.POSTGRESQLHOST = oldDBHost;
+        process.env.POSTGRESQLPORT = oldDBPort;
         process.env.POSTGRESQLUSER = oldDBUser;
+        process.env.POSTGRESQLDATABASE = oldDBDatabase;
     });
 
     it('should pass if variables are present', () => {
-        process.env.POSTGRESQLHOST = 'creds';
-        process.env.POSTGRESQLUSER = 'bucket';
+        process.env.POSTGRESQLHOST = 'localhost';
+        process.env.POSTGRESQLPORT = '5432';
+        process.env.POSTGRESQLUSER = 'postgres';
+        process.env.POSTGRESQLDATABASE = 'mlforkids';
 
         env.confirmRequiredEnvironment();
     });
 
     it('should fail if variables are missing', () => {
+        process.env.POSTGRESQLHOST = 'localhost';
+        process.env.POSTGRESQLPORT = '5432';
         delete process.env.POSTGRESQLUSER;
+        process.env.POSTGRESQLDATABASE = 'mlforkids';
 
         assert.throws(
             () => env.confirmRequiredEnvironment(),
@@ -36,5 +47,6 @@ describe('Utils - env', () => {
     });
 
 });
+
 
 


### PR DESCRIPTION
Fixes #540

## Summary
- Configures `POSTGRESQLPORT` and `POSTGRESQLDATABASE` in `process.env` during positive environment tests.
- Preserves and restores all four required PostgreSQL environment variables in `before()` and `after()` hooks.

## Verification
- `npm run compile` succeeded.
- `node --test dist/tests/utils/env.js` passed all unit tests.